### PR TITLE
Small fixes for Freebuild

### DIFF
--- a/EpicLoot/EpicLoot.cs
+++ b/EpicLoot/EpicLoot.cs
@@ -133,6 +133,7 @@ namespace EpicLoot
         public static ConfigEntry<bool> OutputPatchedConfigFiles;
         public static ConfigEntry<bool> EnchantingTableUpgradesActive;
         public static ConfigEntry<bool> EnableLimitedBountiesInProgress;
+        public static ConfigEntry<bool> EnableFreebuildBossGating;
         public static ConfigEntry<int> MaxInProgressBounties;
         public static ConfigEntry<EnchantingTabs> EnchantingTableActivatedTabs;
 
@@ -334,6 +335,7 @@ namespace EpicLoot
             AbilityBarPosition = Config.Bind("Abilities", "Ability Bar Position", new Vector2(150, 170), "The position offset from the Ability Bar Anchor at which to place the ability bar.");
             AbilityBarLayoutAlignment = Config.Bind("Abilities", "Ability Bar Layout Alignment", TextAnchor.LowerLeft, "The Ability Bar is a Horizontal Layout Group. This value indicates how the elements inside are aligned. Choices with 'Center' in them will keep the items centered on the bar, even if there are fewer than the maximum allowed. 'Left' will be left aligned, and similar for 'Right'.");
             AbilityBarIconSpacing = Config.Bind("Abilities", "Ability Bar Icon Spacing", 8.0f, "The number of units between the icons on the ability bar.");
+            EnableFreebuildBossGating = Config.Bind("Abilities", "Freebuild Requires Boss Kills", true, "Global Keys gate building tiers. Defeating the appropriate boss is required to freebuild pieces that require more than just a workbench.");
 
             // Enchanting Table
             EnchantingTableUpgradesActive = SyncedConfig("Enchanting Table", "Upgrades Active", true, "Toggles Enchanting Table Upgrade Capabilities. If false, enchanting table features will be unlocked set to Level 1");

--- a/EpicLoot/EpicLoot.cs
+++ b/EpicLoot/EpicLoot.cs
@@ -115,6 +115,7 @@ namespace EpicLoot
         public static ConfigEntry<bool> UseGeneratedMagicItemNames;
         private static ConfigEntry<GatedItemTypeMode> _gatedItemTypeModeConfig;
         public static ConfigEntry<GatedBountyMode> BossBountyMode;
+        public static ConfigEntry<GatedPieceTypeMode> GatedFreebuildMode;
         private static ConfigEntry<BossDropMode> _bossTrophyDropMode;
         private static ConfigEntry<float> _bossTrophyDropPlayerRange;
         private static ConfigEntry<int> _andvaranautRange;
@@ -133,7 +134,6 @@ namespace EpicLoot
         public static ConfigEntry<bool> OutputPatchedConfigFiles;
         public static ConfigEntry<bool> EnchantingTableUpgradesActive;
         public static ConfigEntry<bool> EnableLimitedBountiesInProgress;
-        public static ConfigEntry<bool> EnableFreebuildBossGating;
         public static ConfigEntry<int> MaxInProgressBounties;
         public static ConfigEntry<EnchantingTabs> EnchantingTableActivatedTabs;
 
@@ -278,6 +278,8 @@ namespace EpicLoot
                 "skill that the player has unlocked (i.e. swords will stay swords) according to iteminfo.json.");
             BossBountyMode = SyncedConfig("Balance", "Gated Bounty Mode", GatedBountyMode.Unlimited,
                 "Sets whether available bounties are ungated or gated by boss kills.");
+            GatedFreebuildMode = Config.Bind("Balance", "Gated Freebuild Mode", GatedPieceTypeMode.BossKillUnlocksCurrentBiomePieces,
+                "Sets whether available pieces for the Freebuild effect are ungated or gated by boss kills.");
             _bossTrophyDropMode = SyncedConfig("Balance", "Boss Trophy Drop Mode", BossDropMode.OnePerPlayerNearBoss,
                 "Sets bosses to drop a number of trophies equal to the number of players. " +
                 "Optionally set it to only include players within a certain distance, " +
@@ -335,8 +337,7 @@ namespace EpicLoot
             AbilityBarPosition = Config.Bind("Abilities", "Ability Bar Position", new Vector2(150, 170), "The position offset from the Ability Bar Anchor at which to place the ability bar.");
             AbilityBarLayoutAlignment = Config.Bind("Abilities", "Ability Bar Layout Alignment", TextAnchor.LowerLeft, "The Ability Bar is a Horizontal Layout Group. This value indicates how the elements inside are aligned. Choices with 'Center' in them will keep the items centered on the bar, even if there are fewer than the maximum allowed. 'Left' will be left aligned, and similar for 'Right'.");
             AbilityBarIconSpacing = Config.Bind("Abilities", "Ability Bar Icon Spacing", 8.0f, "The number of units between the icons on the ability bar.");
-            EnableFreebuildBossGating = Config.Bind("Abilities", "Freebuild Requires Boss Kills", true, "Global Keys gate building tiers. Defeating the appropriate boss is required to freebuild pieces that require more than just a workbench.");
-
+            
             // Enchanting Table
             EnchantingTableUpgradesActive = SyncedConfig("Enchanting Table", "Upgrades Active", true, "Toggles Enchanting Table Upgrade Capabilities. If false, enchanting table features will be unlocked set to Level 1");
             EnchantingTableActivatedTabs = SyncedConfig("Enchanting Table", $"Table Features Active", EnchantingTabs.Sacrifice | EnchantingTabs.Augment | EnchantingTabs.Enchant | EnchantingTabs.Disenchant | EnchantingTabs.Upgrade | EnchantingTabs.ConvertMaterials, $"Toggles Enchanting Table Feature on and off completely.");

--- a/EpicLoot/src/GatedItemType/GatedItemTypeHelper.cs
+++ b/EpicLoot/src/GatedItemType/GatedItemTypeHelper.cs
@@ -6,6 +6,13 @@ using EpicLoot.Adventure.Feature;
 
 namespace EpicLoot.GatedItemType
 {
+    public enum GatedPieceTypeMode
+    {
+        Unlimited,
+        BossKillUnlocksCurrentBiomePieces,
+        BossKillUnlocksNextBiomePieces
+    }
+
     public enum GatedItemTypeMode
     {
         Unlimited,

--- a/EpicLoot/src/Magic/MagicItemEffects/FreeBuild.cs
+++ b/EpicLoot/src/Magic/MagicItemEffects/FreeBuild.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Reflection;
 using HarmonyLib;
 using JetBrains.Annotations;
@@ -16,6 +17,9 @@ namespace EpicLoot.MagicItemEffects
             yield return AccessTools.DeclaredMethod(typeof(Hud), nameof(Hud.SetupPieceInfo));
         }
 
+        private static Dictionary<string, Boolean> FreeBuildablePieces = new Dictionary<string, bool> { };
+        private static int CurrentGlobalKeyset = 0;
+
         [UsedImplicitly]
         private static void Prefix(ref CraftingStation __state, Piece piece)
         {
@@ -24,33 +28,22 @@ namespace EpicLoot.MagicItemEffects
                 return;
             }
 
+            // maybe we should reduce the frequency of the hashcode check to see if a piece is buildable through changed global keys
+            if (CurrentGlobalKeyset == 0) { CurrentGlobalKeyset = ZoneSystem.instance.m_globalKeys.GetHashCode(); }
+            if (CurrentGlobalKeyset != ZoneSystem.instance.m_globalKeys.GetHashCode()) { FreeBuildablePieces.Clear(); }
+
             __state = piece.m_craftingStation;
-            if (Player.m_localPlayer.HasActiveMagicEffect(MagicEffectType.FreeBuild))
+
+            if (piece.m_craftingStation.name != null && Player.m_localPlayer.HasActiveMagicEffect(MagicEffectType.FreeBuild))
             {
-                switch (piece.m_craftingStation.m_name)
+                if (FreeBuildablePieces.ContainsKey(piece.m_craftingStation.name)) 
                 {
-                    // Building with iron or stone requires having defeated the elder
-                    case "piece_stonecutter":
-                    case "forge":
-                        if (ZoneSystem.instance.GetGlobalKey("defeated_gdking"))
-                        { piece.m_craftingStation = null; }
-                        break;
-                    // building with the artisan table requires defeating moder
-                    case "piece_artisanstation":
-                        if (ZoneSystem.instance.GetGlobalKey("defeated_dragon"))
-                        { piece.m_craftingStation = null; }
-                        break;
-                    // building with the blackforge or galdur table requires defeating yag
-                    case "blackforge":
-                    case "piece_magetable":
-                        if (ZoneSystem.instance.GetGlobalKey("defeated_goblinking"))
-                        { piece.m_craftingStation = null; }
-                        break;
-                    // if we hit default, we've checked everything we know from vanilla, this will ensure the no-cost is applied to mod piece table building requirements
-                    // we could instead start with a check for the workbench and only support vanilla crafting structures- but what fun is that?
-                    default:
-                        piece.m_craftingStation = null;
-                        break;
+                    if (FreeBuildablePieces[piece.m_craftingStation.name] == true) { piece.m_craftingStation = null;  }
+                } else
+                {
+                    bool pieceFreebuild = CanBeFreeBuilt(piece.m_craftingStation.name);
+                    FreeBuildablePieces.Add(piece.m_craftingStation.name, pieceFreebuild);
+                    if (pieceFreebuild) { piece.m_craftingStation = null; }
                 }
             }
         }
@@ -62,6 +55,35 @@ namespace EpicLoot.MagicItemEffects
             {
                 piece.m_craftingStation = __state;
             }
+        }
+
+        private static bool CanBeFreeBuilt(string piece_name)
+        {
+            switch (piece_name)
+            {
+                // Building with iron or stone requires having defeated the elder
+                case "piece_stonecutter":
+                case "forge":
+                    if (ZoneSystem.instance.GetGlobalKey("defeated_gdking"))
+                    { return true; }
+                    break;
+                // building with the artisan table requires defeating moder
+                case "piece_artisanstation":
+                    if (ZoneSystem.instance.GetGlobalKey("defeated_dragon"))
+                    { return true; }
+                    break;
+                // building with the blackforge or galdur table requires defeating yag
+                case "blackforge":
+                case "piece_magetable":
+                    if (ZoneSystem.instance.GetGlobalKey("defeated_goblinking"))
+                    { return true; }
+                    break;
+                // if we hit default, we've checked everything we know from vanilla, this will ensure the no-cost is applied to mod piece table building requirements
+                // we could instead start with a check for the workbench and only support vanilla crafting structures- but what fun is that?
+                default:
+                    return true;
+            }
+            return false;
         }
     }
 }

--- a/EpicLoot/src/Magic/MagicItemEffects/FreeBuild.cs
+++ b/EpicLoot/src/Magic/MagicItemEffects/FreeBuild.cs
@@ -1,6 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Reflection;
+using BepInEx;
 using HarmonyLib;
 using JetBrains.Annotations;
 
@@ -17,10 +17,6 @@ namespace EpicLoot.MagicItemEffects
             yield return AccessTools.DeclaredMethod(typeof(Hud), nameof(Hud.SetupPieceInfo));
         }
 
-        private static Dictionary<string, Boolean> FreeBuildablePieces = new Dictionary<string, bool> { };
-        private static int CurrentGlobalKeyset = 0;
-        private static bool CurrentlyBossGated = true;
-
         [UsedImplicitly]
         private static void Prefix(ref CraftingStation __state, Piece piece)
         {
@@ -29,30 +25,14 @@ namespace EpicLoot.MagicItemEffects
                 return;
             }
 
-            // We always check to see if the config for boss gating has changed or if the bosses killed have changed
-            // This ensures after killing a boss or the config being updated that we rebuild the dictionary of what is freebuildable
-            if (CurrentGlobalKeyset != ZoneSystem.instance.m_globalKeysEnums.Count || CurrentlyBossGated != EpicLoot.EnableFreebuildBossGating.Value)
-            {
-                FreeBuildablePieces.Clear();
-                CurrentGlobalKeyset = ZoneSystem.instance.m_globalKeysEnums.Count;
-                CurrentlyBossGated = EpicLoot.EnableFreebuildBossGating.Value;
-            }
-
             __state = piece.m_craftingStation;
 
-            if (piece.m_craftingStation != null && piece.m_craftingStation.name != null && Player.m_localPlayer.HasActiveMagicEffect(MagicEffectType.FreeBuild))
+            if (piece.m_craftingStation != null && piece.m_craftingStation.name != null &&
+                Player.m_localPlayer.HasActiveMagicEffect(MagicEffectType.FreeBuild))
             {
-                //EpicLoot.Log($"Piece does require a crafting station, and player has freebuild.");
-                if (FreeBuildablePieces.ContainsKey(piece.m_name)) 
+                if (CanBeFreeBuilt(piece))
                 {
-                    // EpicLoot.Log($"Checking diectionary for freebuild status");
-                    if (FreeBuildablePieces[piece.m_name] == true) { piece.m_craftingStation = null;  }
-                } else
-                {
-                    bool pieceFreebuild = CanBeFreeBuilt(piece.m_craftingStation.name);
-                    FreeBuildablePieces.Add(piece.m_name, pieceFreebuild);
-                    // EpicLoot.Log($"Dictionary entry not present, checking freebuild and adding entry {piece.m_name}-{pieceFreebuild}");
-                    if (pieceFreebuild) { piece.m_craftingStation = null; }
+                    piece.m_craftingStation = null;
                 }
             }
         }
@@ -66,46 +46,67 @@ namespace EpicLoot.MagicItemEffects
             }
         }
 
-        private static bool CanBeFreeBuilt(string piece_name)
+        private static bool CanBeFreeBuilt(Piece piece)
         {
-            if (EpicLoot.EnableFreebuildBossGating.Value)
+            if (EpicLoot.GatedFreebuildMode.Value == GatedItemType.GatedPieceTypeMode.Unlimited)
             {
-                switch (piece_name)
-                {
-                    // Building with iron or stone requires having defeated the elder
-                    case "piece_stonecutter":
-                    case "forge":
-                        if (ZoneSystem.instance.GetGlobalKey("defeated_gdking"))
-                        {
-                            EpicLoot.Log($"Stonecutter & forge check for gdking {ZoneSystem.instance.GetGlobalKey("defeated_gdking")}");
-                            return true; 
-                        }
-                        break;
-                    // building with the artisan table requires defeating moder
-                    case "piece_artisanstation":
-                        if (ZoneSystem.instance.GetGlobalKey("defeated_dragon") == true)
-                        {
-                            EpicLoot.Log($"artisan station check for dragon {ZoneSystem.instance.GetGlobalKey("defeated_dragon")}");
-                            return true;
-                        }
-                        break;
-                    // building with the blackforge or galdur table requires defeating yag
-                    case "blackforge":
-                    case "piece_magetable":
-                        if (ZoneSystem.instance.GetGlobalKey("defeated_goblinking"))
-                        {
-                            EpicLoot.Log($"blackforge & magetable check for goblinking {ZoneSystem.instance.GetGlobalKey("defeated_goblinking")}");
-                            return true;
-                        }
-                        break;
-                    // if we hit default, we've checked everything we know from vanilla, this will ensure the no-cost is applied to mod piece table building requirements
-                    // we could instead start with a check for the workbench and only support vanilla crafting structures- but what fun is that?
-                    default:
-                        return true;
-                }
-                return false;
+                return true;
             }
-            // fall through for not enabling global key gate checking of freebuild
+
+            string requiredKey = "";
+
+            switch (piece.m_craftingStation.name)
+            {
+                case "forge":
+                    if (EpicLoot.GatedFreebuildMode.Value == GatedItemType.GatedPieceTypeMode.BossKillUnlocksCurrentBiomePieces)
+                    {
+                        requiredKey = "defeated_eikthyr";
+                    }
+                    else if (EpicLoot.GatedFreebuildMode.Value == GatedItemType.GatedPieceTypeMode.BossKillUnlocksNextBiomePieces)
+                    {
+                        requiredKey = "";
+                    }
+                    break;
+                case "piece_stonecutter":
+                    if (EpicLoot.GatedFreebuildMode.Value == GatedItemType.GatedPieceTypeMode.BossKillUnlocksCurrentBiomePieces)
+                    {
+                        requiredKey = "defeated_gdking";
+                    }
+                    else if (EpicLoot.GatedFreebuildMode.Value == GatedItemType.GatedPieceTypeMode.BossKillUnlocksNextBiomePieces)
+                    {
+                        requiredKey = "defeated_eikthyr";
+                    }
+                    break;
+                case "piece_artisanstation":
+                    if (EpicLoot.GatedFreebuildMode.Value == GatedItemType.GatedPieceTypeMode.BossKillUnlocksCurrentBiomePieces)
+                    {
+                        requiredKey = "defeated_dragon";
+                    }
+                    else if (EpicLoot.GatedFreebuildMode.Value == GatedItemType.GatedPieceTypeMode.BossKillUnlocksNextBiomePieces)
+                    {
+                        requiredKey = "defeated_bonemass";
+                    }
+                    break;
+                case "blackforge":
+                case "piece_magetable":
+                    if (EpicLoot.GatedFreebuildMode.Value == GatedItemType.GatedPieceTypeMode.BossKillUnlocksCurrentBiomePieces)
+                    {
+                        requiredKey = "defeated_goblinking";
+                    }
+                    else if (EpicLoot.GatedFreebuildMode.Value == GatedItemType.GatedPieceTypeMode.BossKillUnlocksNextBiomePieces)
+                    {
+                        requiredKey = "defeated_dragon";
+                    }
+                    break;
+                default:
+                    return true;
+            }
+
+            if (!requiredKey.IsNullOrWhiteSpace())
+            {
+                return ZoneSystem.instance.GetGlobalKey(requiredKey);
+            }
+
             return true;
         }
     }

--- a/EpicLoot/src/Magic/MagicItemEffects/FreeBuild.cs
+++ b/EpicLoot/src/Magic/MagicItemEffects/FreeBuild.cs
@@ -27,7 +27,31 @@ namespace EpicLoot.MagicItemEffects
             __state = piece.m_craftingStation;
             if (Player.m_localPlayer.HasActiveMagicEffect(MagicEffectType.FreeBuild))
             {
-                piece.m_craftingStation = null;
+                switch (piece.m_craftingStation.m_name)
+                {
+                    // Building with iron or stone requires having defeated the elder
+                    case "piece_stonecutter":
+                    case "forge":
+                        if (ZoneSystem.instance.GetGlobalKey("defeated_gdking"))
+                        { piece.m_craftingStation = null; }
+                        break;
+                    // building with the artisan table requires defeating moder
+                    case "piece_artisanstation":
+                        if (ZoneSystem.instance.GetGlobalKey("defeated_dragon"))
+                        { piece.m_craftingStation = null; }
+                        break;
+                    // building with the blackforge or galdur table requires defeating yag
+                    case "blackforge":
+                    case "piece_magetable":
+                        if (ZoneSystem.instance.GetGlobalKey("defeated_goblinking"))
+                        { piece.m_craftingStation = null; }
+                        break;
+                    // if we hit default, we've checked everything we know from vanilla, this will ensure the no-cost is applied to mod piece table building requirements
+                    // we could instead start with a check for the workbench and only support vanilla crafting structures- but what fun is that?
+                    default:
+                        piece.m_craftingStation = null;
+                        break;
+                }
             }
         }
 


### PR DESCRIPTION
- Uses a dictionary key lookup for existing items
- Lazy builds dictionary as pieces are looked up
- Rebuilds the dictionary on global key changes
- Separate key gating for forge,stonecutter & artisan station & blackforge/magetable
- Configuration flag for enabling the per-boss gating of freebuild

Tested with a handful of key configurations and changes.