### PR TITLE
Bugfixes for various things

### DIFF
--- a/EpicLoot/config/magiceffects.json
+++ b/EpicLoot/config/magiceffects.json
@@ -5717,23 +5717,23 @@
       },
       "ValuesPerRarity": {
         "Rare": {
-          "MinValue": 2,
-          "MaxValue": 5,
+          "MinValue": 4,
+          "MaxValue": 10,
           "Increment": 0.5
         },
         "Epic": {
-          "MinValue": 3,
-          "MaxValue": 7,
+          "MinValue": 10,
+          "MaxValue": 18,
           "Increment": 0.5
         },
         "Legendary": {
-          "MinValue": 4,
-          "MaxValue": 9,
+          "MinValue": 18,
+          "MaxValue": 32,
           "Increment": 0.5
         },
         "Mythic": {
-          "MinValue": 5,
-          "MaxValue": 11,
+          "MinValue": 32,
+          "MaxValue": 45,
           "Increment": 0.5
         }
       },

--- a/EpicLoot/src/GamePatches/ItemDrop_Patch_MagicItemTooltip.cs
+++ b/EpicLoot/src/GamePatches/ItemDrop_Patch_MagicItemTooltip.cs
@@ -419,7 +419,7 @@ namespace EpicLoot
             bool lightningMagic = item.HasEffect(MagicEffectType.AddLightningDamage);
             bool poisonMagic = item.HasEffect(MagicEffectType.AddPoisonDamage);
             bool spiritMagic = item.HasEffect(MagicEffectType.AddSpiritDamage);
-            bool coinHoarderMagic = CoinHoarder.HasCoinHoarder(out float coinHoarderEffectValue);
+            bool coinHoarderMagic = CoinHoarder.HasCoinHoarder();
             bool spellswordMagic = item.HasEffect(MagicEffectType.SpellSword);
             Player.m_localPlayer.GetSkills().GetRandomSkillRange(out float min, out float max, skillType);
             string str = String.Empty;

--- a/EpicLoot/src/GamePatches/VisEquipment_Patch.cs
+++ b/EpicLoot/src/GamePatches/VisEquipment_Patch.cs
@@ -212,6 +212,29 @@ namespace EpicLoot
             }
         }
 
+        [HarmonyPatch(typeof(Humanoid), nameof(Humanoid.DropItem))]
+        [HarmonyPostfix]
+        public static void Humanoid_DropITem(Humanoid __instance, ItemDrop.ItemData item)
+        {
+            var equipFx = GetEquipFxName(item, out var mode);
+            if (OtherItemsUseThisEffect(__instance, equipFx, item, mode))
+            {
+                return;
+            }
+
+            if (!string.IsNullOrEmpty(equipFx) && mode == FxAttachMode.Player)
+            {
+                var effect = __instance.transform.Find(equipFx);
+                if (effect == null)
+                {
+                    EpicLoot.LogError($"Unequipped item ({item.m_shared.m_name}) from player that had fx, but could not find fx ({equipFx})!");
+                    return;
+                }
+
+                ZNetScene.instance.Destroy(effect.gameObject);
+            }
+        }
+
         [HarmonyPatch(typeof(Humanoid), nameof(Humanoid.UnequipItem))]
         [HarmonyPrefix]
         public static void Humanoid_UnequipItem_Prefix(Humanoid __instance, ItemDrop.ItemData item, bool triggerEquipEffects)

--- a/EpicLoot/src/GatedItemType/GatedItemTypeHelper.cs
+++ b/EpicLoot/src/GatedItemType/GatedItemTypeHelper.cs
@@ -179,10 +179,9 @@ namespace EpicLoot.GatedItemType
             if (ItemsByTypeAndBoss[itemType].ContainsKey(boss))
             {
                 List<string> items = ItemsByTypeAndBoss[itemType][boss];
-                items.shuffleList();
                 bool gated = true;
 
-                foreach (string item in items)
+                foreach (string item in items.shuffleList())
                 {
                     gated = CheckIfItemNeedsGate(mode, item);
                     if (gated)

--- a/EpicLoot/src/General/Extensions.cs
+++ b/EpicLoot/src/General/Extensions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 
 namespace EpicLoot.General
 {
@@ -10,22 +11,19 @@ namespace EpicLoot.General
         /// <returns></returns>
         public static List<T> shuffleList<T>(this List<T> inputList)
         {
-            int i = 0;
-            int t = inputList.Count;
-            int r = 0;
-            T p = default(T);
+            T p = default;
             List<T> tempList = new List<T>();
             tempList.AddRange(inputList);
-
-            while (i < t)
+            int count = inputList.Count;
+            for (int i = 0; i < count; i++)
             {
-                r = UnityEngine.Random.Range(i, tempList.Count);
+                int tpos = UnityEngine.Random.Range(i, count);
                 p = tempList[i];
-                tempList[i] = tempList[r];
-                tempList[r] = p;
-                i++;
+                tempList[i] = tempList[tpos];
+                tempList[tpos] = p;
             }
-
+            //EpicLoot.Log($"Input list: {string.Join(",", inputList)}");
+            //EpicLoot.Log($"Shuffled l: {string.Join(",", tempList)}");
             return tempList;
         }
     }

--- a/EpicLoot/src/Magic/MagicItemEffects/BulkUp.cs
+++ b/EpicLoot/src/Magic/MagicItemEffects/BulkUp.cs
@@ -60,7 +60,7 @@ namespace EpicLoot.MagicItemEffects
 
         private static void DetermineBulkhealthValue(bool skip_if_set = false)
         {
-            // EpicLoot.Log($"Checking Bulk Health Values, current bonus {health_bonus_from_effect}");
+            //EpicLoot.Log($"Checking Bulk Health Values, current bonus {health_bonus_from_effect}");
             // Skip the details if the value is already set and we arn't updating it.
             if (skip_if_set && health_bonus_from_effect > 0) { return; }
 
@@ -72,15 +72,20 @@ namespace EpicLoot.MagicItemEffects
                 {
                     health_regen_from_food += food2.m_item.m_shared.m_foodRegen;
                 }
-                // The bulkup bonus to health
-                // float bulk_health_bonus = (bulkupValue / 25) + 1;
-                float bulk_health_bonus = (float)Math.Sqrt(bulkupValue / 60f) + 1.2f;
-                if (bulk_health_bonus > 3f) {
-                    bulk_health_bonus = 3f;
+
+                // Include the bonus from the AddHealthRegen effect
+                var regenAmount = Player.m_localPlayer.GetTotalActiveMagicEffectValue(MagicEffectType.AddHealthRegen);
+                if (regenAmount > 0) {
+                    health_regen_from_food += regenAmount;
                 }
+
+                // The bulkup bonus to health
+                float bulk_health_bonus = ((bulkupValue / 30f) * 0.8f) + 1.5f;
                 health_bonus_from_effect = bulk_health_bonus * health_regen_from_food;
-                // EpicLoot.Log($"Bulkup setting bonus health {health_bonus_from_effect}");
-            } else {
+                //EpicLoot.Log($"Regen {health_regen_from_food} Bulkup Health bonus {bulk_health_bonus} = {health_bonus_from_effect}");
+            }
+            else
+            {
                 health_bonus_from_effect = 0;
             }
         }

--- a/EpicLoot/src/Magic/MagicItemEffects/CoinHoarder.cs
+++ b/EpicLoot/src/Magic/MagicItemEffects/CoinHoarder.cs
@@ -14,7 +14,7 @@ public class CoinHoarder
     {
         if (player == null)
         {
-            return 0f;
+            return 1f;
         }
 
         ItemDrop.ItemData[] mcoins = player.m_inventory.GetAllItems()
@@ -22,24 +22,25 @@ public class CoinHoarder
 
         if (mcoins.Length == 0)
         {
-            return 0f;
+            return 1f;
         }
 
         float totalCoins = mcoins.Sum(coin => coin.m_stack);
-        float coinHoarderBonus = Mathf.Log10(effectValue * totalCoins) * 8.7f;
-        return coinHoarderBonus / 100f;
+        if (totalCoins <= 1000) {
+            // Linear fraction increase up till 1000 coins, then logarithmic decay increase (1.145x at 1000)
+            return (1f + totalCoins * 0.000145f);
+        }
+        float coinHoarderBonus = (Mathf.Log10(effectValue * totalCoins) * 5.5f / 150f) + 1f;
+        return coinHoarderBonus;
     }
 
-    public static bool HasCoinHoarder(out float coinHoarderDamageMultiplier)
+    public static bool HasCoinHoarder()
     {
-        coinHoarderDamageMultiplier = 0f;
-        if (Player.m_localPlayer.HasActiveMagicEffect(MagicEffectType.CoinHoarder, out float coinHoarderEffectValue))
+        if (Player.m_localPlayer.HasActiveMagicEffect(MagicEffectType.CoinHoarder, out float _cv))
         {
-            coinHoarderDamageMultiplier = GetCoinHoarderValue(Player.m_localPlayer, coinHoarderEffectValue);
             return true;
         }
-
         return false;
     }
-    
+
 }

--- a/EpicLoot/src/Magic/MagicItemEffects/ExplosiveArrows.cs
+++ b/EpicLoot/src/Magic/MagicItemEffects/ExplosiveArrows.cs
@@ -1,14 +1,48 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using System.Reflection;
-using System.Reflection.Emit;
-using HarmonyLib;
+﻿using HarmonyLib;
 using JetBrains.Annotations;
+using System;
+using System.Collections.Generic;
+using System.Reflection.Emit;
 using UnityEngine;
+using static Attack;
 using Object = UnityEngine.Object;
 
 namespace EpicLoot.MagicItemEffects
 {
+    [HarmonyPatch(typeof(Attack))]
+    public static class ExplodingArrow_Patch
+    {
+        //[HarmonyEmitIL("./dumps")]
+        //[HarmonyDebug]
+        [HarmonyTranspiler]
+        [HarmonyPatch(nameof(Attack.FireProjectileBurst))]
+        static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions /*, ILGenerator generator*/)
+        {
+            var codeMatcher = new CodeMatcher(instructions);
+            codeMatcher.MatchStartForward(
+                new CodeMatch(OpCodes.Ldfld, AccessTools.Field(typeof(Attack), nameof(Attack.m_weapon))),
+                new CodeMatch(OpCodes.Ldloc_S),
+                new CodeMatch(OpCodes.Stfld, AccessTools.Field(typeof(ItemDrop.ItemData), nameof(ItemDrop.ItemData.m_lastProjectile)))
+                ).Advance(3).InsertAndAdvance(
+                new CodeInstruction(OpCodes.Ldloc_S, (byte)20),
+                new CodeInstruction(OpCodes.Ldarg_0),
+                Transpilers.EmitDelegate(UpdateProjectileHit)
+                ).ThrowIfNotMatch("Unable to patch Exploding Arrows AOE.");
+            return codeMatcher.Instructions();
+        }
+
+        private static void UpdateProjectileHit(GameObject shot, Attack instance)
+        {
+            EpicLoot.Log($"Checking to set exploding arrow");
+            if (Player.m_localPlayer != null && instance.m_character == Player.m_localPlayer && Player.m_localPlayer.HasActiveMagicEffect(MagicEffectType.ExplosiveArrows, out float effectValue, 0.01f))
+            {
+                EpicLoot.Log($"Exploding Arrow set for projectile: {effectValue} on {shot.gameObject.name}");
+                shot.GetComponent<Projectile>()?.m_nview.GetZDO().Set("el-aw", effectValue);
+            }
+        }
+    }
+
+
     [HarmonyPatch(typeof(Projectile), nameof(Projectile.Awake))]
     public class RPC_ExplodingArrow_Projectile_Awake_Patch
     {
@@ -17,7 +51,7 @@ namespace EpicLoot.MagicItemEffects
         {
             __instance.m_nview.Register<Vector3, float>("el-aw", RPC_ExplodingArrow);
         }
-            
+
         private static void RPC_ExplodingArrow(long sender, Vector3 position, float explodingArrowStrength)
         {
             var poisonPrefab = ZNetScene.instance.GetPrefab("vfx_blob_attack");
@@ -41,7 +75,7 @@ namespace EpicLoot.MagicItemEffects
                     continue;
                 }
 
-                var fireHit = new HitData {m_damage = {m_fire = explodingArrowStrength}};
+                var fireHit = new HitData { m_damage = { m_fire = explodingArrowStrength } };
                 c.Damage(fireHit);
             }
         }
@@ -51,96 +85,39 @@ namespace EpicLoot.MagicItemEffects
     public class ExplodingArrowHit_Projectile_OnHit_Patch
     {
         [UsedImplicitly]
-        private static void Prefix(out bool __state, Projectile __instance)
+        private static void Prefix(out Tuple<bool, bool> __state, Projectile __instance)
         {
-            __state = __instance.m_stayAfterHitStatic;
+            __state = new Tuple<bool, bool>(__instance.m_stayAfterHitStatic, __instance.m_stayAfterHitDynamic);
             __instance.m_stayAfterHitStatic = true;
+            __instance.m_stayAfterHitDynamic = true;
+            EpicLoot.Log($"Exploding Arrow onhit with static hit state: {__state.Item1}  dynamic hit state: {__state.Item2}");
         }
-        
+
         [UsedImplicitly]
-        private static void Postfix(bool __state, Vector3 hitPoint, Projectile __instance)
+        private static void Postfix(Tuple<bool, bool> __state, Vector3 hitPoint, Projectile __instance)
         {
+            EpicLoot.Log($"Exploding Arrow hit at {hitPoint} with state {__state}");
             if (__instance == null || __instance.m_nview == null || __instance.m_nview.GetZDO() == null)
                 return;
 
             if (__instance.m_didHit)
             {
                 var explodingArrow = __instance.m_nview.GetZDO().GetFloat("el-aw", float.NaN);
+                EpicLoot.Log($"Exploding Arrow hit with strength {explodingArrow}");
                 if (!float.IsNaN(explodingArrow))
                 {
                     var explodingArrowStrength = explodingArrow * __instance.m_damage.GetTotalDamage();
                     __instance.m_nview.InvokeRPC(ZRoutedRpc.Everybody, "el-aw", hitPoint, explodingArrowStrength);
                 }
 
-                if (!__state)
+                if (__state.Item1 || __state.Item2)
                 {
                     ZNetScene.instance.Destroy(__instance.gameObject);
                 }
             }
 
-            __instance.m_stayAfterHitStatic = __state;
-        }
-    }
-
-    [HarmonyPatch(typeof(Attack), nameof(Attack.FireProjectileBurst))]
-    public class ExplodingArrowInstantiation_Attack_FireProjectileBurst_Patch
-    {
-        private static GameObject ChooseAttackProjectile(GameObject defaultAttackProjectile, Attack attack)
-        {
-            if (attack.m_character == Player.m_localPlayer &&
-                Player.m_localPlayer.HasActiveMagicEffect(MagicEffectType.ExplosiveArrows, out float effectValue))
-            {
-                return ObjectDB.instance.GetItemPrefab("ArrowFire").GetComponent<ItemDrop>().m_itemData.m_shared.m_attack.m_attackProjectile;
-            }
-
-            return defaultAttackProjectile;
-        }
-
-        private static GameObject MarkAttackProjectile(GameObject attackProjectile, Attack attack)
-        {
-            if (attack.m_character == Player.m_localPlayer &&
-                Player.m_localPlayer.HasActiveMagicEffect(MagicEffectType.ExplosiveArrows, out float explosiveStrength, 0.01f))
-            {
-                attackProjectile.GetComponent<ZNetView>().GetZDO().Set("el-aw", explosiveStrength);
-            }
-
-            return attackProjectile;
-        }
-
-        private static readonly MethodInfo AttackProjectileMarker = AccessTools.DeclaredMethod(
-            typeof(ExplodingArrowInstantiation_Attack_FireProjectileBurst_Patch), nameof(MarkAttackProjectile));
-        private static readonly MethodInfo AttackProjectileChooser = AccessTools.DeclaredMethod(
-            typeof(ExplodingArrowInstantiation_Attack_FireProjectileBurst_Patch), nameof(ChooseAttackProjectile));
-        private static readonly MethodInfo Instantiator = AccessTools.GetDeclaredMethods(typeof(Object))
-            .Where(m => m.Name == "Instantiate" && m.GetGenericArguments().Length == 1)
-            .Select(m => m.MakeGenericMethod(typeof(GameObject)))
-            .First(m => m.GetParameters().Length == 3 && m.GetParameters()[1].ParameterType == typeof(Vector3));
-
-        [UsedImplicitly]
-        private static IEnumerable<CodeInstruction> Transpiler(IEnumerable<CodeInstruction> instructions)
-        {
-            var result = new List<CodeInstruction>();
-            var searchLdLoc = -1;
-            OpCode[] ldLocOps = {OpCodes.Ldloc_0, OpCodes.Ldloc_1, OpCodes.Ldloc_2, OpCodes.Ldloc_3, OpCodes.Ldloc_S};
-            foreach (var instruction in instructions.Reverse())
-            {
-                if (instruction.opcode == OpCodes.Call && instruction.OperandIs(Instantiator))
-                {
-                    result.Add(new CodeInstruction(OpCodes.Call, AttackProjectileMarker));
-                    result.Add(new CodeInstruction(OpCodes.Ldarg_0)); // this
-                    searchLdLoc = 3;
-                }
-
-                if (ldLocOps.Contains(instruction.opcode) && --searchLdLoc == 0)
-                {
-                    result.Add(new CodeInstruction(OpCodes.Call, AttackProjectileChooser));
-                    result.Add(new CodeInstruction(OpCodes.Ldarg_0)); // this
-                }
-
-                result.Add(instruction);
-            }
-
-            return ((IEnumerable<CodeInstruction>) result).Reverse();
+            __instance.m_stayAfterHitStatic = __state.Item1;
+            __instance.m_stayAfterHitDynamic = __state.Item2;
         }
     }
 }

--- a/EpicLoot/src/Magic/MagicItemEffects/IncreaseDrop.cs
+++ b/EpicLoot/src/Magic/MagicItemEffects/IncreaseDrop.cs
@@ -5,39 +5,20 @@ namespace EpicLoot.MagicItemEffects;
 
 public abstract class IncreaseDrop
 {
-    public string MagicEffect { get; set; }
-    public string ZDOVar { get; set; }
-
-    public void DoPrefix(HitData hit)
-    {
-        if (hit != null)
-        {
-            Player player = Player.m_localPlayer;
-            if (player != null &&
-                MagicEffectsHelper.HasActiveMagicEffectOnWeapon(player, player.GetCurrentWeapon(),
-                    MagicEffect, out float effectValue) &&
-                player.m_nview.GetZDO().GetInt(ZDOVar) != (int)effectValue)
-            {
-                EpicLoot.Log($"Setting {ZDOVar} from prefix to {(int)effectValue}");
-                player.m_nview.GetZDO().Set(ZDOVar, (int)effectValue);
-            }
-        }
-    }
-
-    public void TryDropExtraItems(Character character, DropTable dropTable, Vector3 objPosition)
+    public static void TryDropExtraItems(Character character, string effect, DropTable dropTable, Vector3 objPosition)
     {
         if (character is Player)
         {
-            int effectValue = (character as Player).m_nview.GetZDO().GetInt(ZDOVar);
+            (character as Player).HasActiveMagicEffect(effect, out float effectValue);
 
             if (effectValue > 0)
             {
-                DropExtraItems(dropTable.GetDropList(effectValue), objPosition);
+                DropExtraItems(dropTable.GetDropList(Mathf.RoundToInt(effectValue)), objPosition);
             }
         }
     }
 
-    public void DropExtraItems(List<GameObject> dropList, Vector3 objPosition)
+    public static void DropExtraItems(List<GameObject> dropList, Vector3 objPosition)
     {
         EpicLoot.Log($"DropExtraItems!");
         Vector2 vector = UnityEngine.Random.insideUnitCircle * 0.5f;

--- a/EpicLoot/src/Magic/MagicItemEffects/IncreaseMiningDrop.cs
+++ b/EpicLoot/src/Magic/MagicItemEffects/IncreaseMiningDrop.cs
@@ -5,43 +5,6 @@ namespace EpicLoot.MagicItemEffects;
 
 public class IncreaseMiningDrop : IncreaseDrop
 {
-    public static IncreaseMiningDrop Instance { get; private set; }
-
-    static IncreaseMiningDrop()
-    {
-        Instance = new IncreaseMiningDrop()
-        {
-            MagicEffect = MagicEffectType.IncreaseMiningDrop,
-            ZDOVar = "el-mining"
-        };
-    }
-
-    // Reset ZDO variable on equipment change
-    [HarmonyPatch(typeof(Humanoid), nameof(Humanoid.EquipItem))]
-    [HarmonyPatch(typeof(Humanoid), nameof(Humanoid.UnequipItem))]
-    public static class IncreaseMiningDrop_Player_EquipmentChange_Patches
-    {
-        public static void Postfix(Humanoid __instance)
-        {
-            if (__instance == Player.m_localPlayer && __instance.m_nview.IsValid())
-            {
-                if (__instance.m_nview.GetZDO().GetInt(Instance.ZDOVar) != 0)
-                {
-                    EpicLoot.Log("Resetting mining drop variable");
-                    __instance.m_nview.GetZDO().Set(Instance.ZDOVar, 0);
-                }
-            }
-        }
-    }
-
-    [HarmonyPatch(typeof(MineRock), nameof(MineRock.Damage))]
-    public static class IncreaseMiningDrop_MineRock_Damage_Patch
-    {
-        private static void Prefix(MineRock __instance, HitData hit)
-        {
-            Instance.DoPrefix(hit);
-        }
-    }
 
     [HarmonyPatch(typeof(MineRock), nameof(MineRock.RPC_Hit))]
     public static class IncreaseMiningDrop_MineRock_RPC_Hit_Patch
@@ -50,17 +13,8 @@ public class IncreaseMiningDrop : IncreaseDrop
         {
             if (hit != null && __instance.m_nview == null)
             {
-                Instance.TryDropExtraItems(hit.GetAttacker(), __instance.m_dropItems, __instance.transform.position);
+                TryDropExtraItems(hit.GetAttacker(), MagicEffectType.IncreaseMiningDrop, __instance.m_dropItems, __instance.transform.position);
             }
-        }
-    }
-
-    [HarmonyPatch(typeof(MineRock5), nameof(MineRock5.Damage))]
-    public static class IncreaseMiningDrop_MineRock5_Damage_Patch
-    {
-        private static void Prefix(MineRock5 __instance, HitData hit)
-        {
-            Instance.DoPrefix(hit);
         }
     }
 
@@ -74,21 +28,7 @@ public class IncreaseMiningDrop : IncreaseDrop
                 var hitArea = __instance.GetHitArea(hitAreaIndex);
                 Vector3 position = (__instance.m_hitEffectAreaCenter && hitArea.m_collider != null) ?
                     hitArea.m_collider.bounds.center : hit.m_point;
-                Instance.TryDropExtraItems(hit.GetAttacker(), __instance.m_dropItems, position);
-            }
-        }
-    }
-
-    [HarmonyPatch(typeof(Destructible), nameof(Destructible.Damage))]
-    public static class IncreaseMiningDrop_Destructible_Damage_Patch
-    {
-        private static void Prefix(Destructible __instance, HitData hit)
-        {
-            if (__instance.GetDestructibleType() == DestructibleType.Default &&
-                __instance.m_damages.m_chop == HitData.DamageModifier.Immune &&
-                __instance.m_damages.m_pickaxe != HitData.DamageModifier.Immune)
-            {
-                Instance.DoPrefix(hit);
+                TryDropExtraItems(hit.GetAttacker(), MagicEffectType.IncreaseMiningDrop, __instance.m_dropItems, position);
             }
         }
     }
@@ -108,7 +48,7 @@ public class IncreaseMiningDrop : IncreaseDrop
                     return;
                 }
 
-                Instance.TryDropExtraItems(hit.GetAttacker(), dropList.m_dropWhenDestroyed, __instance.transform.position);
+                TryDropExtraItems(hit.GetAttacker(), MagicEffectType.IncreaseMiningDrop, dropList.m_dropWhenDestroyed, __instance.transform.position);
             }
         }
     }

--- a/EpicLoot/src/Magic/MagicItemEffects/IncreaseTreeDrop.cs
+++ b/EpicLoot/src/Magic/MagicItemEffects/IncreaseTreeDrop.cs
@@ -4,40 +4,6 @@ namespace EpicLoot.MagicItemEffects;
 
 public class IncreaseTreeDrop : IncreaseDrop
 {
-    public static IncreaseTreeDrop Instance { get; private set; }
-
-    static IncreaseTreeDrop()
-    {
-        Instance = new IncreaseTreeDrop()
-        {
-            MagicEffect = MagicEffectType.IncreaseTreeDrop,
-            ZDOVar = "el-tree"
-        };
-    }
-
-    // Reset ZDO variable on equipment change
-    [HarmonyPatch(typeof(Humanoid), nameof(Humanoid.EquipItem))]
-    [HarmonyPatch(typeof(Humanoid), nameof(Humanoid.UnequipItem))]
-    public static class IncreaseTreeDrop_Player_EquipmentChange_Patches
-    {
-        public static void Postfix(Humanoid __instance)
-        {
-            if (__instance == Player.m_localPlayer && __instance.m_nview.GetZDO().GetInt(Instance.ZDOVar) != 0)
-            {
-                EpicLoot.Log("Resetting tree drop variable");
-                __instance.m_nview.GetZDO().Set(Instance.ZDOVar, 0);
-            }
-        }
-    }
-
-    [HarmonyPatch(typeof(TreeLog), nameof(TreeLog.Damage))]
-    public static class IncreaseTreeDrop_TreeLog_Damage_Patch
-    {
-        private static void Prefix(TreeLog __instance, HitData hit)
-        {
-            Instance.DoPrefix(hit);
-        }
-    }
 
     [HarmonyPatch(typeof(TreeLog), nameof(TreeLog.Destroy))]
     public static class IncreaseTreeDrop_TreeLog_Destroy_Patch
@@ -46,17 +12,8 @@ public class IncreaseTreeDrop : IncreaseDrop
         {
             if (hitData != null)
             {
-                Instance.TryDropExtraItems(hitData.GetAttacker(), __instance.m_dropWhenDestroyed, __instance.transform.position);
+                TryDropExtraItems(hitData.GetAttacker(), MagicEffectType.IncreaseTreeDrop, __instance.m_dropWhenDestroyed, __instance.transform.position);
             }
-        }
-    }
-
-    [HarmonyPatch(typeof(TreeBase), nameof(TreeBase.Damage))]
-    public static class IncreaseTreeDrop_TreeBase_Damage_Patch
-    {
-        private static void Prefix(TreeBase __instance, HitData hit)
-        {
-            Instance.DoPrefix(hit);
         }
     }
 
@@ -67,19 +24,7 @@ public class IncreaseTreeDrop : IncreaseDrop
         {
             if (hit != null && __instance.m_nview == null && !__instance.gameObject.activeSelf)
             {
-                Instance.TryDropExtraItems(hit.GetAttacker(), __instance.m_dropWhenDestroyed, __instance.transform.position);
-            }
-        }
-    }
-
-    [HarmonyPatch(typeof(Destructible), nameof(Destructible.Damage))]
-    public static class IncreaseTreeDrop_Destructible_Damage_Patch
-    {
-        private static void Prefix(Destructible __instance, HitData hit)
-        {
-            if (__instance.GetDestructibleType() == DestructibleType.Tree)
-            {
-                Instance.DoPrefix(hit);
+                TryDropExtraItems(hit.GetAttacker(), MagicEffectType.IncreaseTreeDrop, __instance.m_dropWhenDestroyed, __instance.transform.position);
             }
         }
     }
@@ -97,7 +42,7 @@ public class IncreaseTreeDrop : IncreaseDrop
                     return;
                 }
 
-                Instance.TryDropExtraItems(hit.GetAttacker(), dropList.m_dropWhenDestroyed, __instance.transform.position);
+                TryDropExtraItems(hit.GetAttacker(), MagicEffectType.IncreaseTreeDrop, dropList.m_dropWhenDestroyed, __instance.transform.position);
             }
         }
     }

--- a/EpicLoot/src/Magic/MagicItemEffects/ModifyDamage.cs
+++ b/EpicLoot/src/Magic/MagicItemEffects/ModifyDamage.cs
@@ -11,7 +11,7 @@ namespace EpicLoot.MagicItemEffects
             if (Player.m_localPlayer &&
                 Player.m_localPlayer.HasActiveMagicEffect(MagicEffectType.CoinHoarder, out float coinHoarderEffectValue))
             {
-                var modifier = 1 + CoinHoarder.GetCoinHoarderValue(Player.m_localPlayer, coinHoarderEffectValue);
+                var modifier = CoinHoarder.GetCoinHoarderValue(Player.m_localPlayer, coinHoarderEffectValue);
                 if (modifier > 0)
                 {
                     __result.m_blunt *= modifier;

--- a/EpicLoot/src/Magic/MagicItemEffects/ModifySummonHealth.cs
+++ b/EpicLoot/src/Magic/MagicItemEffects/ModifySummonHealth.cs
@@ -1,79 +1,25 @@
-using System.Collections.Generic;
 using HarmonyLib;
-using UnityEngine;
 
 namespace EpicLoot.MagicItemEffects;
 
+[HarmonyPatch(typeof(Character), nameof(Character.SetMaxHealth))]
 public class ModifySummonHealth
 {
-    /*private static readonly Dictionary<Humanoid, float> originalHealth = new Dictionary<Humanoid, float>();
-
-    [HarmonyPatch(typeof(Attack), nameof(Attack.FireProjectileBurst))]
-    public class ModifySummonHealth_Attack_FireProjectileBurst_Patch
+    public static void Prefix(Character __instance, ref float health)
     {
-        public static void Prefix(Attack __instance)
+        if (!__instance.IsTamed()) { return; }
+        //EpicLoot.Log($"Checking for Summon Health Increase {__instance.name} {health}");
+
+        Tameable isTamable = __instance.GetComponent<Tameable>();
+        if (isTamable == null) { return; }
+        if (isTamable.m_levelUpOwnerSkill == Skills.SkillType.BloodMagic || isTamable.m_levelUpOwnerSkill == Skills.SkillType.ElementalMagic)
         {
-            if (!(__instance.m_character is Player player) ||
-                !MagicEffectsHelper.HasActiveMagicEffect(player, __instance.m_weapon, MagicEffectType.ModifySummonHealth, out float effectValue) ||
-                __instance.m_attackProjectile == null)
+            if (Player.m_localPlayer != null && Player.m_localPlayer.HasActiveMagicEffect(MagicEffectType.ModifySummonHealth, out float effectValue, 0.01f))
             {
-                return;
+                //EpicLoot.Log($"Increasing summon health {effectValue}%");
+                health *= (1 + effectValue);
             }
-
-            if (!__instance.m_attackProjectile.TryGetComponent<SpawnAbility>(out var spawnAbility))
-            {
-                return;
-            }
-
-            var spawnPrefab = spawnAbility.m_spawnPrefab[0];
-            if (spawnPrefab == null)
-            {
-                return;
-            }
-
-            if (!spawnPrefab.TryGetComponent<Humanoid>(out var humanoid))
-            {
-                return;
-            }
-
-            if (!originalHealth.ContainsKey(humanoid))
-            {
-                originalHealth[humanoid] = humanoid.m_health;
-            }
-
-            humanoid.m_health *= 1 + effectValue;
         }
 
-        public static void Postfix(Attack __instance)
-        {
-            if (__instance.m_attackProjectile == null)
-            {
-                return;
-            }
-
-            var spawnProjectile = __instance.m_attackProjectile;
-            if (!spawnProjectile.TryGetComponent<SpawnAbility>(out var spawnAbility))
-            {
-                return;
-            }
-
-            var spawnPrefab = spawnAbility.m_spawnPrefab[0];
-            
-            if (spawnPrefab == null)
-            {
-                return;
-            }
-
-            if (!spawnPrefab.TryGetComponent<Humanoid>(out var humanoid))
-            {
-                return;
-            }
-
-            if (originalHealth.TryGetValue(humanoid, out var origHealth))
-            {
-                humanoid.m_health = origHealth;
-                originalHealth.Remove(humanoid);
-            }
-        }
-    }*/
+    }
 }

--- a/EpicLoot/src/Magic/MagicItemEffects/QuickDraw.cs
+++ b/EpicLoot/src/Magic/MagicItemEffects/QuickDraw.cs
@@ -1,18 +1,33 @@
 ﻿using System;
 using HarmonyLib;
-using JetBrains.Annotations;
 
 namespace EpicLoot.MagicItemEffects
 {
-    [HarmonyPatch(typeof(Player), nameof(Player.GetSkillFactor))]
-    public class QuickDrawBowSkillIncrease_Player_GetSkillFactor_Patch
+    [HarmonyPatch(typeof(Humanoid), nameof(Humanoid.GetAttackDrawPercentage))]
+    public class QuickDrawBow_Player_GetAttackDrawPercentage_Patch
     {
-        [UsedImplicitly]
-        private static void Postfix(Player __instance, Skills.SkillType skill, ref float __result)
+        private static void Postfix(Player __instance, ref float __result)
         {
-            if (skill == Skills.SkillType.Bows && __instance.GetTotalActiveMagicEffectValue(MagicEffectType.QuickDraw, 0.01f) is float bowDrawTimeReduction)
+            if (__instance.HasActiveMagicEffect(MagicEffectType.QuickDraw, out float bowDrawTimeReduction, 0.01f))
             {
-                __result = Math.Min(1, __result + bowDrawTimeReduction);
+                float reduction = Math.Min(1, __result *= (1 + bowDrawTimeReduction));
+                __result = reduction;
+            }
+        }
+    }
+
+    [HarmonyPatch(typeof(ItemDrop.ItemData), nameof(ItemDrop.ItemData.GetWeaponLoadingTime))]
+    public class Quickdraw_Player_GetWeaponLoadingTime
+    {
+        private static void Postfix(ItemDrop.ItemData __instance, ref float __result)
+        {
+            if (Player.m_localPlayer != null && Player.m_localPlayer.GetTotalActiveMagicEffectValue(MagicEffectType.QuickDraw, 0.01f) is float crossbowReloadSpeed)
+            {
+                if (crossbowReloadSpeed > 0 && __instance.m_shared.m_attack.m_requiresReload || __instance.m_shared.m_secondaryAttack.m_requiresReload)
+                {
+                    if (__instance.m_shared.m_attack.m_requiresReload) { __result = __instance.m_shared.m_attack.m_reloadTime * (1f - crossbowReloadSpeed); }
+                    if (__instance.m_shared.m_secondaryAttack.m_requiresReload) { __result = __instance.m_shared.m_secondaryAttack.m_reloadTime * (1f - crossbowReloadSpeed); }
+                }
             }
         }
     }


### PR DESCRIPTION
- Visual equipment bugfix
- GatedItem helper (randomization fix)
- Bulkup tuning and limit removal
- Explosive arrow patch update
- Increase drop changes (multiplayer testing needed)
- Modify summon damage
- Modify summon health
- Quickdraw


Notes:
Tested with bows before hoes, explosive arrow now leaves the correct arrow. Explosive arrow needed some additional state passed to ensure it triggers when hitting all things, instead of just statics.. (who wants to shoot NEXT to your target for 20% damage?)