### PR TITLE
Extract enums out of `EpicLoot.cs`.

### DIFF
--- a/EpicLoot/EpicLoot.cs
+++ b/EpicLoot/EpicLoot.cs
@@ -26,27 +26,6 @@ using Object = UnityEngine.Object;
 
 namespace EpicLoot
 {
-    public enum LogLevel
-    {
-        Info,
-        Warning,
-        Error
-    }
-
-    public enum BossDropMode
-    {
-        Default,
-        OnePerPlayerOnServer,
-        OnePerPlayerNearBoss
-    }
-
-    public enum GatedBountyMode
-    {
-        Unlimited,
-        BossKillUnlocksCurrentBiomeBounties,
-        BossKillUnlocksNextBiomeBounties
-    }
-
     public sealed class EpicAssets
     {
         public AssetBundle AssetBundle;

--- a/EpicLoot/src/Enums/BossDropMode.cs
+++ b/EpicLoot/src/Enums/BossDropMode.cs
@@ -1,0 +1,9 @@
+﻿namespace EpicLoot
+{
+    public enum BossDropMode
+    {
+        Default,
+        OnePerPlayerOnServer,
+        OnePerPlayerNearBoss
+    }
+}

--- a/EpicLoot/src/Enums/GatedBountyMode.cs
+++ b/EpicLoot/src/Enums/GatedBountyMode.cs
@@ -1,0 +1,9 @@
+﻿namespace EpicLoot
+{
+    public enum GatedBountyMode
+    {
+        Unlimited,
+        BossKillUnlocksCurrentBiomeBounties,
+        BossKillUnlocksNextBiomeBounties
+    }
+}

--- a/EpicLoot/src/Enums/LogLevel.cs
+++ b/EpicLoot/src/Enums/LogLevel.cs
@@ -1,0 +1,9 @@
+﻿namespace EpicLoot
+{
+    public enum LogLevel
+    {
+        Info,
+        Warning,
+        Error
+    }
+}


### PR DESCRIPTION
* No change in logic or behaviour expected.
* Enums can be moved into where they are logically used in a future change.