### PR TITLE
Patches only apply on first run without refresh core configs

### DIFF
--- a/EpicLoot/EpicLoot.cs
+++ b/EpicLoot/EpicLoot.cs
@@ -143,7 +143,7 @@ namespace EpicLoot
             Jotunn.Logger.LogInfo("Loading unitylib");
             LoadEmbeddedAssembly(assembly, "EpicLoot-UnityLib.dll");
             Jotunn.Logger.LogInfo("Setting up config");
-            FilePatching.LoadAllPatches();
+
             cfg = new ELConfig(Config);
             FilePatching.ApplyAllPatches();
             // Set the referenced common logger to the EL specific reference so that common things get logged

--- a/EpicLoot/src/Config/ELConfig.cs
+++ b/EpicLoot/src/Config/ELConfig.cs
@@ -142,6 +142,7 @@ namespace EpicLoot.Config
             cfg.SaveOnConfigSet = true;
             CreateConfigValues(Config);
             SetupConfigRPCs();
+            FilePatching.LoadAllPatches();
             InitializeConfig();
         }
 
@@ -413,8 +414,8 @@ namespace EpicLoot.Config
             if (File.Exists(basecfglocation) == false || AlwaysRefreshCoreConfigs.Value) {
                 EpicLoot.Log($"Base config file {basecfglocation} does not exist, creating it from embedded default config.");
                 var overhaulfiledata = EpicLoot.ReadEmbeddedResourceFile(GetDefaultEmbeddedFileLocation(filename));
-                FilePatching.LoadPatchedJSON(filename.Split('.')[0], true);
                 File.WriteAllText(basecfglocation, overhaulfiledata);
+                FilePatching.LoadPatchedJSON(filename.Split('.')[0], true);
             }
 
             // Attempt to parse the core config, if its not valid use the embedded default config

--- a/EpicLoot/src/Patching/FilePatching.cs
+++ b/EpicLoot/src/Patching/FilePatching.cs
@@ -1,5 +1,6 @@
 ﻿using BepInEx;
 using Common;
+
 using EpicLoot.Config;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -105,7 +106,7 @@ namespace EpicLoot.Patching
             }
             catch (Exception e)
             {
-                Debug.LogWarning($"Unable to Get Patch Directory: {e.Message}");
+                Debug.LogWarning($"Unable to Get Patch Directory: {e.StackTrace}");
                 var debugPath = GetPatchesDirectoryPath(true);
                 Debug.LogWarning($"Attempted PatchesDirPath is [{PatchesDirPath}]");
                 Debug.LogWarning($"Attempted debugPath is [{debugPath}]");


### PR DESCRIPTION
Makes patches apply PER FILE on generation (eg, you can delete a specific core config and get it regenerated) or delete all and get them generated.

Patches are still loaded but not applied if you do not have refresh core configs set.