### PR TITLE
Epic loot 0.12.8

### DIFF
--- a/EpicLoot/CHANGELOG.md
+++ b/EpicLoot/CHANGELOG.md
@@ -11,6 +11,7 @@
   * Added Ooze to Swamp BiomeMaterials.
   * Fixed Plains having the bonemass boss key rather than defeated_goblinking.
 * Removed throwable bombs showing up as a possible unidentifiable item roll.
+* Added mod compatibility for Steady Regeneration (broke in 0.12.6).
 
 ## Version 0.12.7
 

--- a/EpicLoot/CHANGELOG.md
+++ b/EpicLoot/CHANGELOG.md
@@ -1,8 +1,21 @@
+## Version 0.12.8
+
+* Many configuration tweaks. Delete and regenerate the json files specified to get the changes for each or grab the fixes manually if you have made changes:
+* adventuredata.json, enchantcosts.json: Added default configurations for "None" and "Misc" item types. This will fix support for some modded items like "Bows Before Hoes" quivers.
+  * If you see other items with no costs in the enchanting table it is related to this issue. Please report issues only after refreshing your base configurations.
+* enchantcosts.json: 
+  * New field IsUnidentified for DisenchantProducts to better distinguish the configuration for these items with the previous change.
+  * Changed identify CostByRarity blackforest cost to Bronze to match other items.
+* loottables.json: Fixed a bug with the auto sorter misclassifying items if their first crafting material was lower tier than the rest.
+* itemsorter.json:
+  * Added Ooze to Swamp BiomeMaterials.
+  * Fixed Plains having the bonemass boss key rather than defeated_goblinking.
+* Removed throwable bombs showing up as a possible unidentifiable item roll.
+
 ## Version 0.12.7
 
 * Reworked magic effects OffSet Attack and DodgeBuff to fix bugs including missing assets (sound and visuals).
 * Normalized OffSet Attack values in magiceffects.json, this value represents the percentage of damage reduction (15-40%).
-  * Delete and regenerate this file in your baseconfig folder or grab the fix manually if you have made changes.
 * Bug fix for enchanting table identify costs not applying for more than one cost item.
 * Compatibility improvement for other inventory mods, should recognize magic items in additional slots when equipped.
 * Bug fix for spam accepting bounties at the merchant and fixed errors when closing the store UI before completed.

--- a/EpicLoot/EpicLoot.cs
+++ b/EpicLoot/EpicLoot.cs
@@ -32,6 +32,7 @@ namespace EpicLoot;
 [BepInDependency("randyknapp.mods.auga", BepInDependency.DependencyFlags.SoftDependency)]
 [BepInDependency("vapok.mods.adventurebackpacks", BepInDependency.DependencyFlags.SoftDependency)]
 [BepInDependency("kg.ValheimEnchantmentSystem", BepInDependency.DependencyFlags.SoftDependency)]
+[BepInDependency("org.bepinex.plugins.steadyregeneration", BepInDependency.DependencyFlags.SoftDependency)]
 public sealed class EpicLoot : BaseUnityPlugin
 {
     public const string PluginId = "randyknapp.mods.epicloot";

--- a/EpicLoot/EpicLoot.cs
+++ b/EpicLoot/EpicLoot.cs
@@ -36,7 +36,7 @@ public sealed class EpicLoot : BaseUnityPlugin
 {
     public const string PluginId = "randyknapp.mods.epicloot";
     public const string DisplayName = "Epic Loot";
-    public const string Version = "0.12.7";
+    public const string Version = "0.12.8";
 
     private static string ConfigFileName = PluginId + ".cfg";
     private static string ConfigFileFullPath = BepInEx.Paths.ConfigPath + Path.DirectorySeparatorChar + ConfigFileName;

--- a/EpicLoot/Properties/AssemblyInfo.cs
+++ b/EpicLoot/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.12.7")]
-[assembly: AssemblyFileVersion("0.12.7")]
+[assembly: AssemblyVersion("0.12.8")]
+[assembly: AssemblyFileVersion("0.12.8")]

--- a/EpicLoot/config/adventuredata.json
+++ b/EpicLoot/config/adventuredata.json
@@ -55,7 +55,9 @@
       "HeadArmor",
       "ShouldersArmor",
       "Utility",
-      "Trinket"
+      "Trinket",
+      "None",
+      "Misc"
     ],
     "GamblesCount": 4,
     "GambleRarityChance": [ 10, 68, 15, 4, 2, 1 ],

--- a/EpicLoot/config/enchantcosts.json
+++ b/EpicLoot/config/enchantcosts.json
@@ -151,7 +151,9 @@
         "Legs",
         "Shoulder",
         "Utility",
-        "Trinket"
+        "Trinket",
+        "None",
+        "Misc"
       ],
       "Rarity": "Magic",
       "Products": [
@@ -174,7 +176,9 @@
         "Legs",
         "Shoulder",
         "Utility",
-        "Trinket"
+        "Trinket",
+        "None",
+        "Misc"
       ],
       "Rarity": "Rare",
       "Products": [
@@ -197,7 +201,9 @@
         "Legs",
         "Shoulder",
         "Utility",
-        "Trinket"
+        "Trinket",
+        "None",
+        "Misc"
       ],
       "Rarity": "Epic",
       "Products": [
@@ -220,7 +226,9 @@
         "Legs",
         "Shoulder",
         "Utility",
-        "Trinket"
+        "Trinket",
+        "None",
+        "Misc"
       ],
       "Rarity": "Legendary",
       "Products": [
@@ -243,7 +251,9 @@
         "Legs",
         "Shoulder",
         "Utility",
-        "Trinket"
+        "Trinket",
+        "None",
+        "Misc"
       ],
       "Rarity": "Mythic",
       "Products": [
@@ -799,10 +809,7 @@
       ]
     },
     {
-      "IsMagic": true,
-      "ItemTypes": [
-        "Misc"
-      ],
+      "IsUnidentified": true,
       "Rarity": "Magic",
       "Products": [
         {
@@ -820,10 +827,7 @@
       ]
     },
     {
-      "IsMagic": true,
-      "ItemTypes": [
-        "Misc"
-      ],
+      "IsUnidentified": true,
       "Rarity": "Rare",
       "Products": [
         {
@@ -841,10 +845,7 @@
       ]
     },
     {
-      "IsMagic": true,
-      "ItemTypes": [
-        "Misc"
-      ],
+      "IsUnidentified": true,
       "Rarity": "Epic",
       "Products": [
         {
@@ -862,10 +863,7 @@
       ]
     },
     {
-      "IsMagic": true,
-      "ItemTypes": [
-        "Misc"
-      ],
+      "IsUnidentified": true,
       "Rarity": "Legendary",
       "Products": [
         {
@@ -883,10 +881,7 @@
       ]
     },
     {
-      "IsMagic": true,
-      "ItemTypes": [
-        "Misc"
-      ],
+      "IsUnidentified": true,
       "Rarity": "Mythic",
       "Products": [
         {
@@ -1038,7 +1033,9 @@
         "Legs",
         "Shoulder",
         "Utility",
-        "Trinket"
+        "Trinket",
+        "None",
+        "Misc"
       ],
       "Rarity": "Magic",
       "Cost": [
@@ -1064,7 +1061,9 @@
         "Legs",
         "Shoulder",
         "Utility",
-        "Trinket"
+        "Trinket",
+        "None",
+        "Misc"
       ],
       "Rarity": "Rare",
       "Cost": [
@@ -1090,7 +1089,9 @@
         "Legs",
         "Shoulder",
         "Utility",
-        "Trinket"
+        "Trinket",
+        "None",
+        "Misc"
       ],
       "Rarity": "Epic",
       "Cost": [
@@ -1116,7 +1117,9 @@
         "Legs",
         "Shoulder",
         "Utility",
-        "Trinket"
+        "Trinket",
+        "None",
+        "Misc"
       ],
       "Rarity": "Legendary",
       "Cost": [
@@ -1142,7 +1145,9 @@
         "Legs",
         "Shoulder",
         "Utility",
-        "Trinket"
+        "Trinket",
+        "None",
+        "Misc"
       ],
       "Rarity": "Mythic",
       "Cost": [
@@ -1295,7 +1300,9 @@
         "Legs",
         "Shoulder",
         "Utility",
-        "Trinket"
+        "Trinket",
+        "None",
+        "Misc"
       ],
       "Rarity": "Magic",
       "Cost": [
@@ -1321,7 +1328,9 @@
         "Legs",
         "Shoulder",
         "Utility",
-        "Trinket"
+        "Trinket",
+        "None",
+        "Misc"
       ],
       "Rarity": "Rare",
       "Cost": [
@@ -1347,7 +1356,9 @@
         "Legs",
         "Shoulder",
         "Utility",
-        "Trinket"
+        "Trinket",
+        "None",
+        "Misc"
       ],
       "Rarity": "Epic",
       "Cost": [
@@ -1373,7 +1384,9 @@
         "Legs",
         "Shoulder",
         "Utility",
-        "Trinket"
+        "Trinket",
+        "None",
+        "Misc"
       ],
       "Rarity": "Legendary",
       "Cost": [
@@ -1399,7 +1412,9 @@
         "Legs",
         "Shoulder",
         "Utility",
-        "Trinket"
+        "Trinket",
+        "None",
+        "Misc"
       ],
       "Rarity": "Mythic",
       "Cost": [
@@ -1475,7 +1490,9 @@
         "Legs",
         "Shoulder",
         "Utility",
-        "Trinket"
+        "Trinket",
+        "None",
+        "Misc"
       ],
       "Rarity": "Magic",
       "Cost": [
@@ -1499,7 +1516,9 @@
         "Legs",
         "Shoulder",
         "Utility",
-        "Trinket"
+        "Trinket",
+        "None",
+        "Misc"
       ],
       "Rarity": "Rare",
       "Cost": [
@@ -1523,7 +1542,9 @@
         "Legs",
         "Shoulder",
         "Utility",
-        "Trinket"
+        "Trinket",
+        "None",
+        "Misc"
       ],
       "Rarity": "Epic",
       "Cost": [
@@ -1547,7 +1568,9 @@
         "Legs",
         "Shoulder",
         "Utility",
-        "Trinket"
+        "Trinket",
+        "None",
+        "Misc"
       ],
       "Rarity": "Legendary",
       "Cost": [
@@ -1571,7 +1594,9 @@
         "Legs",
         "Shoulder",
         "Utility",
-        "Trinket"
+        "Trinket",
+        "None",
+        "Misc"
       ],
       "Rarity": "Mythic",
       "Cost": [
@@ -1597,7 +1622,9 @@
         "Legs",
         "Shoulder",
         "Utility",
-        "Trinket"
+        "Trinket",
+        "None",
+        "Misc"
       ],
       "Rarity": "Magic",
       "Cost": [
@@ -1621,7 +1648,9 @@
         "Legs",
         "Shoulder",
         "Utility",
-        "Trinket"
+        "Trinket",
+        "None",
+        "Misc"
       ],
       "Rarity": "Rare",
       "Cost": [
@@ -1645,7 +1674,9 @@
         "Legs",
         "Shoulder",
         "Utility",
-        "Trinket"
+        "Trinket",
+        "None",
+        "Misc"
       ],
       "Rarity": "Epic",
       "Cost": [
@@ -1669,7 +1700,9 @@
         "Legs",
         "Shoulder",
         "Utility",
-        "Trinket"
+        "Trinket",
+        "None",
+        "Misc"
       ],
       "Rarity": "Legendary",
       "Cost": [
@@ -1693,7 +1726,9 @@
         "Legs",
         "Shoulder",
         "Utility",
-        "Trinket"
+        "Trinket",
+        "None",
+        "Misc"
       ],
       "Rarity": "Mythic",
       "Cost": [
@@ -1900,32 +1935,32 @@
       "CostByRarity": {
         "Magic": [
           {
-            "Item": "GreydwarfEye",
-            "Amount": 5
+            "Item": "Bronze",
+            "Amount": 1
           }
         ],
         "Rare": [
           {
-            "Item": "GreydwarfEye",
-            "Amount": 10
+            "Item": "Bronze",
+            "Amount": 2
           }
         ],
         "Epic": [
           {
-            "Item": "GreydwarfEye",
-            "Amount": 15
+            "Item": "Bronze",
+            "Amount": 3
           }
         ],
         "Legendary": [
           {
-            "Item": "GreydwarfEye",
-            "Amount": 20
+            "Item": "Bronze",
+            "Amount": 4
           }
         ],
         "Mythic": [
           {
-            "Item": "GreydwarfEye",
-            "Amount": 25
+            "Item": "Bronze",
+            "Amount": 5
           }
         ]
       }

--- a/EpicLoot/config/itemsorter.json
+++ b/EpicLoot/config/itemsorter.json
@@ -84,7 +84,8 @@
         "ElderBark",
         "Guck",
         "Chitin",
-        "SerpentScale"
+        "SerpentScale",
+        "Ooze"
       ],
       "BiomeSpecificCraftingStations": []
     },
@@ -104,7 +105,7 @@
     },
     "Plains": {
       "Tier": "Tier5",
-      "BossKey": "defeated_bonemass",
+      "BossKey": "defeated_goblinking",
       "BiomeMaterials": [
         "Needle",
         "BlackMetal",

--- a/EpicLoot/src/Crafting/AugmentHelper.cs
+++ b/EpicLoot/src/Crafting/AugmentHelper.cs
@@ -2,7 +2,6 @@
 using EpicLoot_UnityLib;
 using Jotunn.Managers;
 using System.Collections.Generic;
-using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
 using Object = UnityEngine.Object;
@@ -19,81 +18,85 @@ namespace EpicLoot.Crafting
 
         public static AugmentChoiceDialog CreateAugmentChoiceDialog(bool useEnchantingUpgrades)
         {
-            var augmentChoices = 3;
+            int augmentChoices = 3;
             if (useEnchantingUpgrades && EnchantingTableUI.instance && EnchantingTableUI.instance.SourceTable)
             {
-                var featureValues = EnchantingTableUI.instance.SourceTable.GetFeatureCurrentValue(EnchantingFeature.Augment);
+                System.Tuple<float, float> featureValues = EnchantingTableUI.instance.SourceTable.GetFeatureCurrentValue(EnchantingFeature.Augment);
                 if (!float.IsNaN(featureValues.Item1))
+                {
                     augmentChoices = (int)featureValues.Item1 + 1;
+                }
             }
 
-            var inventoryGui = InventoryGui.instance;
+            InventoryGui inventoryGui = InventoryGui.instance;
             AugmentChoiceDialog choiceDialog;
             //if (EpicLoot.HasAuga)
             //{
-                //var resultDialog = Auga.API.Workbench_CreateNewResultsPanel();
-                //resultDialog.SetActive(false);
+            //var resultDialog = Auga.API.Workbench_CreateNewResultsPanel();
+            //resultDialog.SetActive(false);
 
-                //choiceDialog = resultDialog.AddComponent<AugmentChoiceDialog>();
+            //choiceDialog = resultDialog.AddComponent<AugmentChoiceDialog>();
 
-                //var icon = choiceDialog.transform.Find("InventoryElement/icon").GetComponent<Image>();
-                //choiceDialog.MagicBG = Object.Instantiate(icon, icon.transform.parent);
-                //choiceDialog.MagicBG.name = "MagicItemBG";
-                //choiceDialog.MagicBG.sprite = EpicLoot.GetMagicItemBgSprite();
-                //choiceDialog.MagicBG.color = Color.white;
-                //choiceDialog.MagicBG.rectTransform.anchorMin = new Vector2(0, 0);
-                //choiceDialog.MagicBG.rectTransform.anchorMax = new Vector2(1, 1);
-                //choiceDialog.MagicBG.rectTransform.sizeDelta = new Vector2(0, 0);
-                //choiceDialog.MagicBG.rectTransform.anchoredPosition = new Vector2(0, 0);
+            //var icon = choiceDialog.transform.Find("InventoryElement/icon").GetComponent<Image>();
+            //choiceDialog.MagicBG = Object.Instantiate(icon, icon.transform.parent);
+            //choiceDialog.MagicBG.name = "MagicItemBG";
+            //choiceDialog.MagicBG.sprite = EpicLoot.GetMagicItemBgSprite();
+            //choiceDialog.MagicBG.color = Color.white;
+            //choiceDialog.MagicBG.rectTransform.anchorMin = new Vector2(0, 0);
+            //choiceDialog.MagicBG.rectTransform.anchorMax = new Vector2(1, 1);
+            //choiceDialog.MagicBG.rectTransform.sizeDelta = new Vector2(0, 0);
+            //choiceDialog.MagicBG.rectTransform.anchoredPosition = new Vector2(0, 0);
 
-                //choiceDialog.NameText = choiceDialog.transform.Find("Topic").GetComponent<TMP_Text>();
+            //choiceDialog.NameText = choiceDialog.transform.Find("Topic").GetComponent<TMP_Text>();
 
-                //var closeButton = choiceDialog.gameObject.GetComponentInChildren<Button>();
-                //Object.Destroy(closeButton.gameObject);
+            //var closeButton = choiceDialog.gameObject.GetComponentInChildren<Button>();
+            //Object.Destroy(closeButton.gameObject);
 
-                //var tooltipHeight = 360;
-                //var buttonStart = -220;
-                //if (augmentChoices > 3)
-                //{
-                //    var extra = augmentChoices - 3;
-                //    tooltipHeight -= extra * 40;
-                //    buttonStart += extra * 40;
-                //}
+            //var tooltipHeight = 360;
+            //var buttonStart = -220;
+            //if (augmentChoices > 3)
+            //{
+            //    var extra = augmentChoices - 3;
+            //    tooltipHeight -= extra * 40;
+            //    buttonStart += extra * 40;
+            //}
 
-                //var tooltip = (RectTransform)choiceDialog.transform.Find("TooltipScrollContainer");
-                //tooltip.SetSizeWithCurrentAnchors(RectTransform.Axis.Vertical, tooltipHeight);
-                //var scrollbar = (RectTransform)choiceDialog.transform.Find("ScrollBar");
-                //scrollbar.SetSizeWithCurrentAnchors(RectTransform.Axis.Vertical, tooltipHeight);
+            //var tooltip = (RectTransform)choiceDialog.transform.Find("TooltipScrollContainer");
+            //tooltip.SetSizeWithCurrentAnchors(RectTransform.Axis.Vertical, tooltipHeight);
+            //var scrollbar = (RectTransform)choiceDialog.transform.Find("ScrollBar");
+            //scrollbar.SetSizeWithCurrentAnchors(RectTransform.Axis.Vertical, tooltipHeight);
 
-                //for (var i = 0; i < augmentChoices; i++)
-                //{
-                //    //var button = Auga.API.MediumButton_Create(resultDialog.transform, $"AugmentButton{i}", string.Empty);
-                //    //Auga.API.Button_SetTextColors(button, Color.white, Color.white, Color.white, Color.white, Color.white, Color.white);
-                //    //button.navigation = new Navigation { mode = Navigation.Mode.None };
+            //for (var i = 0; i < augmentChoices; i++)
+            //{
+            //    //var button = Auga.API.MediumButton_Create(resultDialog.transform, $"AugmentButton{i}", string.Empty);
+            //    //Auga.API.Button_SetTextColors(button, Color.white, Color.white, Color.white, Color.white, Color.white, Color.white);
+            //    //button.navigation = new Navigation { mode = Navigation.Mode.None };
 
-                //    //var focus = Object.Instantiate(EpicLoot.LoadAsset<GameObject>("ButtonFocusAuga"), button.transform);
-                //    //focus.SetActive(false);
-                //    //focus.name = "ButtonFocus";
+            //    //var focus = Object.Instantiate(EpicLoot.LoadAsset<GameObject>("ButtonFocusAuga"), button.transform);
+            //    //focus.SetActive(false);
+            //    //focus.name = "ButtonFocus";
 
-                //    //var rt = (RectTransform)button.transform;
-                //    //rt.anchoredPosition = new Vector2(0, buttonStart - (i * 40));
-                //    //rt.SetSizeWithCurrentAnchors(RectTransform.Axis.Horizontal, 295);
-                //    //choiceDialog.EffectChoiceButtons.Add(button);
-                //}
+            //    //var rt = (RectTransform)button.transform;
+            //    //rt.anchoredPosition = new Vector2(0, buttonStart - (i * 40));
+            //    //rt.SetSizeWithCurrentAnchors(RectTransform.Axis.Horizontal, 295);
+            //    //choiceDialog.EffectChoiceButtons.Add(button);
+            //}
             //}
             //else
             //{
-                
+
             //}
-            var height = 550.0f;
+
+            float height = 550.0f;
             if (augmentChoices > 3)
             {
-                var extra = augmentChoices - 3;
+                int extra = augmentChoices - 3;
                 height += extra * 45;
             }
+
             choiceDialog = CreateDialog<AugmentChoiceDialog>(inventoryGui, "AugmentChoiceDialog", height);
 
-            var background = choiceDialog.gameObject.transform.Find("Frame").gameObject.RectTransform();
+            RectTransform background = choiceDialog.gameObject.transform.Find("Frame").gameObject.RectTransform();
             choiceDialog.MagicBG = Object.Instantiate(inventoryGui.m_recipeIcon, background);
             choiceDialog.MagicBG.name = "MagicItemBG";
             choiceDialog.MagicBG.sprite = EpicLoot.GetMagicItemBgSprite();
@@ -105,8 +108,8 @@ namespace EpicLoot.Crafting
             choiceDialog.Description.rectTransform.SetSizeWithCurrentAnchors(RectTransform.Axis.Vertical, 340);
             choiceDialog.Icon = Object.Instantiate(inventoryGui.m_recipeIcon, background);
 
-            var scrollview = CraftSuccessDialog.ConvertToScrollingDescription(choiceDialog.Description, background);
-            var svrt = (RectTransform)scrollview.transform;
+            ScrollRect scrollview = CraftSuccessDialog.ConvertToScrollingDescription(choiceDialog.Description, background);
+            RectTransform svrt = (RectTransform)scrollview.transform;
             svrt.SetSiblingIndex(1);
             svrt.anchorMin = new Vector2(0, 0);
             svrt.anchorMax = new Vector2(1, 1);
@@ -115,10 +118,10 @@ namespace EpicLoot.Crafting
             svrt.sizeDelta = new Vector2(-20, -300);
             svrt.SetInsetAndSizeFromParentEdge(RectTransform.Edge.Top, 74, 300);
 
-            var closeButton = choiceDialog.gameObject.GetComponentInChildren<Button>();
+            Button closeButton = choiceDialog.gameObject.GetComponentInChildren<Button>();
             Object.Destroy(closeButton.gameObject);
 
-            for (var i = 0; i < augmentChoices; i++)
+            for (int i = 0; i < augmentChoices; i++)
             {
                 Button button = GUIManager.Instance.CreateButton(
                     text: "Augment",
@@ -129,10 +132,10 @@ namespace EpicLoot.Crafting
                     width: 300f,
                     height: 40f).GetComponent<Button>();
                 button.interactable = true;
-                var focus = Object.Instantiate(EpicLoot.LoadAsset<GameObject>("ButtonFocus"), button.transform);
+                GameObject focus = Object.Instantiate(EpicLoot.LoadAsset<GameObject>("ButtonFocus"), button.transform);
                 focus.SetActive(false);
                 focus.name = "ButtonFocus";
-                var rt = button.gameObject.RectTransform();
+                RectTransform rt = button.gameObject.RectTransform();
                 rt.SetSizeWithCurrentAnchors(RectTransform.Axis.Horizontal, 300);
                 rt.SetSizeWithCurrentAnchors(RectTransform.Axis.Vertical, 40);
                 choiceDialog.EffectChoiceButtons.Add(button);
@@ -143,18 +146,19 @@ namespace EpicLoot.Crafting
 
         public static T CreateDialog<T>(InventoryGui inventoryGui, string name, float height = 550) where T : Component
         {
-            var newDialog = Object.Instantiate(inventoryGui.m_variantDialog, inventoryGui.m_variantDialog.transform.parent);
+            VariantDialog newDialog = Object.Instantiate(inventoryGui.m_variantDialog, inventoryGui.m_variantDialog.transform.parent);
             T newDialogT = newDialog.gameObject.AddComponent<T>();
             Object.Destroy(newDialog);
             newDialogT.gameObject.name = name;
 
-            var background = newDialogT.gameObject.transform.Find("VariantFrame").gameObject.RectTransform();
+            RectTransform background = newDialogT.gameObject.transform.Find("VariantFrame").gameObject.RectTransform();
             background.gameObject.name = "Frame";
             for (int i = 1; i < background.transform.childCount; ++i)
             {
-                var child = background.transform.GetChild(i);
+                Transform child = background.transform.GetChild(i);
                 Object.Destroy(child.gameObject);
             }
+
             background.SetSizeWithCurrentAnchors(RectTransform.Axis.Horizontal, 380);
             background.SetSizeWithCurrentAnchors(RectTransform.Axis.Vertical, height);
             background.anchoredPosition += new Vector2(20, -270);
@@ -165,10 +169,10 @@ namespace EpicLoot.Crafting
         public static List<MagicItemEffectDefinition> GetAvailableAugments(
             AugmentRecipe recipe, ItemDrop.ItemData item, MagicItem magicItem, ItemRarity rarity)
         {
-            var valuelessEffect = false;
+            bool valuelessEffect = false;
             if (recipe.EffectIndex >= 0 && recipe.EffectIndex < magicItem.Effects.Count)
             {
-                var currentEffectDef = MagicItemEffectDefinitions.Get(magicItem.Effects[recipe.EffectIndex].EffectType);
+                MagicItemEffectDefinition currentEffectDef = MagicItemEffectDefinitions.Get(magicItem.Effects[recipe.EffectIndex].EffectType);
                 valuelessEffect = currentEffectDef.GetValuesForRarity(rarity) == null;
             }
 
@@ -176,39 +180,42 @@ namespace EpicLoot.Crafting
                 item.Extended(), item.GetMagicItem(), valuelessEffect ? -1 : recipe.EffectIndex, checkaugment: true);
         }
 
-        public static string GetAugmentSelectorText(MagicItem magicItem, int i, IReadOnlyList<MagicItemEffect> augmentableEffects, ItemRarity rarity)
+        public static string GetAugmentSelectorText(MagicItem magicItem, int i,
+            IReadOnlyList<MagicItemEffect> augmentableEffects, ItemRarity rarity)
         {
-            var pip = EpicLoot.GetMagicEffectPip(magicItem.IsEffectAugmented(i));
+            string pip = EpicLoot.GetMagicEffectPip(magicItem.IsEffectAugmented(i));
             bool free = EnchantCostsHelper.EffectIsDeprecated(augmentableEffects[i].EffectType);
+
             return $"{pip} {Localization.instance.Localize(MagicItem.GetEffectText(augmentableEffects[i], rarity, true))}" +
                 $"{(free ? " [<color=yellow>*FREE</color>]" : "")}";
         }
 
         public static List<KeyValuePair<ItemDrop, int>> GetAugmentCosts(ItemDrop.ItemData item, int recipeEffectIndex)
         {
-            var rarity = item.GetRarity();
+            List<KeyValuePair<ItemDrop, int>> costList = new List<KeyValuePair<ItemDrop, int>>();
+            ItemRarity rarity = item.GetRarity();
 
-            var augmentCostDef = EnchantCostsHelper.GetAugmentCost(item, rarity, recipeEffectIndex);
+            List<ItemAmountConfig> augmentCostDef = EnchantCostsHelper.GetAugmentCost(item, rarity, recipeEffectIndex);
             if (augmentCostDef == null)
             {
-                return null;
+                return costList;
             }
 
-            var costList = new List<KeyValuePair<ItemDrop, int>>();
-
-            foreach (var itemAmountConfig in augmentCostDef)
+            foreach (ItemAmountConfig itemAmountConfig in augmentCostDef)
             {
-                var prefab = ObjectDB.instance.GetItemPrefab(itemAmountConfig.Item);
+                GameObject prefab = ObjectDB.instance.GetItemPrefab(itemAmountConfig.Item);
                 if (prefab == null)
                 {
-                    EpicLoot.LogWarning($"Tried to add unknown item ({itemAmountConfig.Item}) to augment cost for item ({item.m_shared.m_name})");
+                    EpicLoot.LogWarning($"Tried to add unknown item ({itemAmountConfig.Item}) " +
+                        $"to augment cost for item ({item.m_shared.m_name})");
                     continue;
                 }
 
-                var itemDrop = prefab.GetComponent<ItemDrop>();
+                ItemDrop itemDrop = prefab.GetComponent<ItemDrop>();
                 if (itemDrop == null)
                 {
-                    EpicLoot.LogWarning($"Tried to add item without ItemDrop ({itemAmountConfig.Item}) to augment cost for item ({item.m_shared.m_name})");
+                    EpicLoot.LogWarning($"Tried to add item without ItemDrop ({itemAmountConfig.Item}) " +
+                        $"to augment cost for item ({item.m_shared.m_name})");
                     continue;
                 }
 

--- a/EpicLoot/src/Crafting/AugmentHelper.cs
+++ b/EpicLoot/src/Crafting/AugmentHelper.cs
@@ -32,55 +32,55 @@ namespace EpicLoot.Crafting
             AugmentChoiceDialog choiceDialog;
             //if (EpicLoot.HasAuga)
             //{
-            //var resultDialog = Auga.API.Workbench_CreateNewResultsPanel();
-            //resultDialog.SetActive(false);
+                //var resultDialog = Auga.API.Workbench_CreateNewResultsPanel();
+                //resultDialog.SetActive(false);
 
-            //choiceDialog = resultDialog.AddComponent<AugmentChoiceDialog>();
+                //choiceDialog = resultDialog.AddComponent<AugmentChoiceDialog>();
 
-            //var icon = choiceDialog.transform.Find("InventoryElement/icon").GetComponent<Image>();
-            //choiceDialog.MagicBG = Object.Instantiate(icon, icon.transform.parent);
-            //choiceDialog.MagicBG.name = "MagicItemBG";
-            //choiceDialog.MagicBG.sprite = EpicLoot.GetMagicItemBgSprite();
-            //choiceDialog.MagicBG.color = Color.white;
-            //choiceDialog.MagicBG.rectTransform.anchorMin = new Vector2(0, 0);
-            //choiceDialog.MagicBG.rectTransform.anchorMax = new Vector2(1, 1);
-            //choiceDialog.MagicBG.rectTransform.sizeDelta = new Vector2(0, 0);
-            //choiceDialog.MagicBG.rectTransform.anchoredPosition = new Vector2(0, 0);
+                //var icon = choiceDialog.transform.Find("InventoryElement/icon").GetComponent<Image>();
+                //choiceDialog.MagicBG = Object.Instantiate(icon, icon.transform.parent);
+                //choiceDialog.MagicBG.name = "MagicItemBG";
+                //choiceDialog.MagicBG.sprite = EpicLoot.GetMagicItemBgSprite();
+                //choiceDialog.MagicBG.color = Color.white;
+                //choiceDialog.MagicBG.rectTransform.anchorMin = new Vector2(0, 0);
+                //choiceDialog.MagicBG.rectTransform.anchorMax = new Vector2(1, 1);
+                //choiceDialog.MagicBG.rectTransform.sizeDelta = new Vector2(0, 0);
+                //choiceDialog.MagicBG.rectTransform.anchoredPosition = new Vector2(0, 0);
 
-            //choiceDialog.NameText = choiceDialog.transform.Find("Topic").GetComponent<TMP_Text>();
+                //choiceDialog.NameText = choiceDialog.transform.Find("Topic").GetComponent<TMP_Text>();
 
-            //var closeButton = choiceDialog.gameObject.GetComponentInChildren<Button>();
-            //Object.Destroy(closeButton.gameObject);
+                //var closeButton = choiceDialog.gameObject.GetComponentInChildren<Button>();
+                //Object.Destroy(closeButton.gameObject);
 
-            //var tooltipHeight = 360;
-            //var buttonStart = -220;
-            //if (augmentChoices > 3)
-            //{
-            //    var extra = augmentChoices - 3;
-            //    tooltipHeight -= extra * 40;
-            //    buttonStart += extra * 40;
-            //}
+                //var tooltipHeight = 360;
+                //var buttonStart = -220;
+                //if (augmentChoices > 3)
+                //{
+                //    var extra = augmentChoices - 3;
+                //    tooltipHeight -= extra * 40;
+                //    buttonStart += extra * 40;
+                //}
 
-            //var tooltip = (RectTransform)choiceDialog.transform.Find("TooltipScrollContainer");
-            //tooltip.SetSizeWithCurrentAnchors(RectTransform.Axis.Vertical, tooltipHeight);
-            //var scrollbar = (RectTransform)choiceDialog.transform.Find("ScrollBar");
-            //scrollbar.SetSizeWithCurrentAnchors(RectTransform.Axis.Vertical, tooltipHeight);
+                //var tooltip = (RectTransform)choiceDialog.transform.Find("TooltipScrollContainer");
+                //tooltip.SetSizeWithCurrentAnchors(RectTransform.Axis.Vertical, tooltipHeight);
+                //var scrollbar = (RectTransform)choiceDialog.transform.Find("ScrollBar");
+                //scrollbar.SetSizeWithCurrentAnchors(RectTransform.Axis.Vertical, tooltipHeight);
 
-            //for (var i = 0; i < augmentChoices; i++)
-            //{
-            //    //var button = Auga.API.MediumButton_Create(resultDialog.transform, $"AugmentButton{i}", string.Empty);
-            //    //Auga.API.Button_SetTextColors(button, Color.white, Color.white, Color.white, Color.white, Color.white, Color.white);
-            //    //button.navigation = new Navigation { mode = Navigation.Mode.None };
+                //for (var i = 0; i < augmentChoices; i++)
+                //{
+                //    //var button = Auga.API.MediumButton_Create(resultDialog.transform, $"AugmentButton{i}", string.Empty);
+                //    //Auga.API.Button_SetTextColors(button, Color.white, Color.white, Color.white, Color.white, Color.white, Color.white);
+                //    //button.navigation = new Navigation { mode = Navigation.Mode.None };
 
-            //    //var focus = Object.Instantiate(EpicLoot.LoadAsset<GameObject>("ButtonFocusAuga"), button.transform);
-            //    //focus.SetActive(false);
-            //    //focus.name = "ButtonFocus";
+                //    //var focus = Object.Instantiate(EpicLoot.LoadAsset<GameObject>("ButtonFocusAuga"), button.transform);
+                //    //focus.SetActive(false);
+                //    //focus.name = "ButtonFocus";
 
-            //    //var rt = (RectTransform)button.transform;
-            //    //rt.anchoredPosition = new Vector2(0, buttonStart - (i * 40));
-            //    //rt.SetSizeWithCurrentAnchors(RectTransform.Axis.Horizontal, 295);
-            //    //choiceDialog.EffectChoiceButtons.Add(button);
-            //}
+                //    //var rt = (RectTransform)button.transform;
+                //    //rt.anchoredPosition = new Vector2(0, buttonStart - (i * 40));
+                //    //rt.SetSizeWithCurrentAnchors(RectTransform.Axis.Horizontal, 295);
+                //    //choiceDialog.EffectChoiceButtons.Add(button);
+                //}
             //}
             //else
             //{

--- a/EpicLoot/src/Crafting/EnchantCostsConfig.cs
+++ b/EpicLoot/src/Crafting/EnchantCostsConfig.cs
@@ -23,6 +23,7 @@ namespace EpicLoot.Crafting
     [Serializable]
     public class DisenchantProductsConfig
     {
+        public bool IsUnidentified;
         public bool IsMagic;
         public ItemRarity Rarity;
         public List<string> ItemTypes = new List<string>();

--- a/EpicLoot/src/Crafting/EnchantCostsHelper.cs
+++ b/EpicLoot/src/Crafting/EnchantCostsHelper.cs
@@ -32,17 +32,23 @@ namespace EpicLoot.Crafting
 
         public static List<ItemAmountConfig> GetSacrificeProducts(ItemDrop.ItemData item)
         {
-            var isMagic = item.IsMagic();
-            var type = item.m_shared.m_itemType;
-            var name = item.m_shared.m_name;
+            bool isMagic = item.IsMagic();
+            bool isUnidentified = item.IsUnidentified();
+            ItemDrop.ItemData.ItemType type = item.m_shared.m_itemType;
+            string name = item.m_shared.m_name;
 
-            var configEntry = Config.DisenchantProducts.Find(x => {
-                if (x.IsMagic && !isMagic)
+            DisenchantProductsConfig configEntry = Config.DisenchantProducts.Find(x => {
+                if (x.IsMagic != (isMagic || isUnidentified))
                 {
                     return false;
                 }
 
-                if (isMagic && x.Rarity != item.GetRarity())
+                if (x.IsUnidentified != isUnidentified)
+                {
+                    return false;
+                }
+
+                if ((isUnidentified || isMagic) && x.Rarity != item.GetRarity())
                 {
                     return false;
                 }
@@ -65,7 +71,7 @@ namespace EpicLoot.Crafting
 
         public static List<ItemAmountConfig> GetSacrificeProducts(bool isMagic, ItemDrop.ItemData.ItemType type, ItemRarity rarity )
         {
-            var configEntry = Config.DisenchantProducts.Find(x => {
+            DisenchantProductsConfig configEntry = Config.DisenchantProducts.Find(x => {
                 if (x.IsMagic && !isMagic)
                 {
                     return false;
@@ -89,9 +95,9 @@ namespace EpicLoot.Crafting
 
         public static List<ItemAmountConfig> GetEnchantCost(ItemDrop.ItemData item, ItemRarity rarity)
         {
-            var type = item.m_shared.m_itemType;
+            ItemDrop.ItemData.ItemType type = item.m_shared.m_itemType;
 
-            var configEntry = Config.EnchantCosts.Find(x => {
+            EnchantCostConfig configEntry = Config.EnchantCosts.Find(x => {
                 if (x.Rarity != rarity)
                 {
                     return false;
@@ -113,9 +119,10 @@ namespace EpicLoot.Crafting
             List<ItemAmountConfig> totalCost = new List<ItemAmountConfig>();
 
             // Add biome-specific costs by rarity if configured
-            if (Config.IdentifyCosts.TryGetValue(biome, out var biomeConfig) &&
-                biomeConfig.CostByRarity.TryGetValue(rarity, out var rarityCosts))
+            if (Config.IdentifyCosts.TryGetValue(biome, out IdentifyCostConfig biomeConfig) &&
+                biomeConfig.CostByRarity.TryGetValue(rarity, out List<ItemAmountConfig> rarityCosts))
             {
+                EpicLoot.Log($"The {rarityCosts[0].Item} amount is {rarityCosts[0].Amount}");
                 totalCost.AddRange(rarityCosts);
             }
             else
@@ -124,7 +131,7 @@ namespace EpicLoot.Crafting
             }
 
             // Add category-specific costs
-            if (Config.IdentifyTypes.TryGetValue(category, out var typeConfig))
+            if (Config.IdentifyTypes.TryGetValue(category, out IdentifyTypeConfig typeConfig))
             {
                 totalCost.AddRange(typeConfig.Costs);
             }
@@ -139,7 +146,7 @@ namespace EpicLoot.Crafting
         public static Dictionary<string, string> GetIdentificationCategories()
         {
             Dictionary<string, string> categories = new Dictionary<string, string>();
-            foreach(var identifyStyle in Config.IdentifyTypes)
+            foreach(KeyValuePair<string, IdentifyTypeConfig> identifyStyle in Config.IdentifyTypes)
             {
                 categories.Add(identifyStyle.Key, identifyStyle.Value.Localization);
             }
@@ -168,7 +175,7 @@ namespace EpicLoot.Crafting
                     break;
             }
 
-            var configEntry = cfg.Find(x =>
+            RuneCostConfig configEntry = cfg.Find(x =>
             {
                 if (x.Rarity != rarity)
                 {
@@ -193,9 +200,14 @@ namespace EpicLoot.Crafting
 
         public static List<ItemAmountConfig> GetAugmentCost(ItemDrop.ItemData item, ItemRarity rarity, int recipeEffectIndex)
         {
-            var type = item.m_shared.m_itemType;
+            if (EffectIsDeprecated(item, recipeEffectIndex))
+            {
+                return new List<ItemAmountConfig>();
+            }
 
-            var configEntry = Config.AugmentCosts.Find(x => {
+            ItemDrop.ItemData.ItemType type = item.m_shared.m_itemType;
+
+            AugmentCostConfig configEntry = Config.AugmentCosts.Find(x => {
                 if (x.Rarity != rarity)
                 {
                     return false;
@@ -209,15 +221,10 @@ namespace EpicLoot.Crafting
                 return true;
             });
 
-            if (EffectIsDeprecated(item, recipeEffectIndex))
-            {
-                return new List<ItemAmountConfig>();
-            }
-
             if (configEntry != null && !item.GetMagicItem().IsEffectAugmented(recipeEffectIndex))
             {
-                var cost = configEntry.Cost.ToList();
-                var reaugmentCost = GetReAugmentCost(item, recipeEffectIndex);
+                List<ItemAmountConfig> cost = configEntry.Cost.ToList();
+                ItemAmountConfig reaugmentCost = GetReAugmentCost(item, recipeEffectIndex);
                 if (reaugmentCost != null)
                 {
                     cost.Add(reaugmentCost);
@@ -235,23 +242,23 @@ namespace EpicLoot.Crafting
                 return null;
             }
 
-            var magicItem = item.GetMagicItem();
+            MagicItem magicItem = item.GetMagicItem();
             if (magicItem == null)
             {
                 return null;
             }
 
-            var totalAugments = magicItem.GetAugmentCount();
+            int totalAugments = magicItem.GetAugmentCount();
             if (totalAugments == 0)
             {
                 return null;
             }
 
-            var featureValues = EnchantingTableUI.instance.SourceTable.GetFeatureCurrentValue(EnchantingFeature.Augment);
-            var reenchantCostReduction = float.IsNaN(featureValues.Item2) ? 0 : (featureValues.Item2 / 100.0f);
+            Tuple<float, float> featureValues = EnchantingTableUI.instance.SourceTable.GetFeatureCurrentValue(EnchantingFeature.Augment);
+            float reenchantCostReduction = float.IsNaN(featureValues.Item2) ? 0 : (featureValues.Item2 / 100.0f);
 
-            var reaugmentCostIndex = Mathf.Clamp(totalAugments - 1, 0, Config.ReAugmentCosts.Count - 1);
-            var baseCost = Config.ReAugmentCosts[reaugmentCostIndex];
+            int reaugmentCostIndex = Mathf.Clamp(totalAugments - 1, 0, Config.ReAugmentCosts.Count - 1);
+            ItemAmountConfig baseCost = Config.ReAugmentCosts[reaugmentCostIndex];
             return new ItemAmountConfig()
             {
                 Item = baseCost.Item,
@@ -261,13 +268,13 @@ namespace EpicLoot.Crafting
 
         public static bool EffectIsDeprecated(ItemDrop.ItemData item, int effectIndex)
         {
-            var effects = item?.GetMagicItem()?.GetEffects();
+            List<MagicItemEffect> effects = item?.GetMagicItem()?.GetEffects();
             return (effects != null && effectIndex >= 0 && effectIndex < effects.Count && EffectIsDeprecated(effects[effectIndex].EffectType));
         }
 
         public static bool ItemHasDeprecatedEffect(ItemDrop.ItemData item)
         {
-            var effects = item?.GetMagicItem()?.GetEffects();
+            List<MagicItemEffect> effects = item?.GetMagicItem()?.GetEffects();
             if (effects != null)
             {
                 for (int index = 0; index < effects.Count; index++)

--- a/EpicLoot/src/Crafting/ItemDrop_Patch.cs
+++ b/EpicLoot/src/Crafting/ItemDrop_Patch.cs
@@ -13,10 +13,9 @@ namespace EpicLoot.Crafting
             bool isMagic = __instance.m_itemData.IsMagicCraftingMaterial();
             bool isRunestone = __instance.m_itemData.IsRunestone();
             bool isUnidentified = __instance.m_itemData.IsUnidentified();
+
             if (isMagic || isRunestone || isUnidentified)
             {
-
-
                 var particleContainer = __instance.transform.Find("Particles");
                 if (particleContainer != null)
                 {
@@ -30,12 +29,14 @@ namespace EpicLoot.Crafting
 
                 // Ensure unidenfitied items are loaded back up if they somehow become non-magical
                 MagicItemComponent mi = __instance.m_itemData.Data().GetOrCreate<MagicItemComponent>();
-                if (isUnidentified && mi.MagicItem == null) {
+                if (isUnidentified && mi.MagicItem == null)
+                {
                     mi.SetMagicItem(new MagicItem
                     {
                         Rarity = rarity,
                         IsUnidentified = true,
                     });
+
                     mi.Save();
                 }
 
@@ -43,7 +44,12 @@ namespace EpicLoot.Crafting
                 {
                     __instance.gameObject.AddComponent<BeamColorSetter>().SetColor(rgbaColor);
                 }
-                if (isUnidentified) { variant = 0; }
+
+                if (isUnidentified)
+                {
+                    variant = 0;
+                }
+
                 __instance.m_itemData.m_variant = variant;
             }
         }

--- a/EpicLoot/src/CraftingV2/EnchantingUIController.cs
+++ b/EpicLoot/src/CraftingV2/EnchantingUIController.cs
@@ -1296,7 +1296,7 @@ namespace EpicLoot.CraftingV2
         private static List<InventoryItemListElement> GetDisenchantCost(ItemDrop.ItemData item)
         {
             List<InventoryItemListElement> result = new List<InventoryItemListElement>();
-            if (item == null || !item.IsMagic())
+            if (item == null || !item.IsMagic() || item.IsUnidentified())
             {
                 return result;
             }

--- a/EpicLoot/src/Magic/MagicItemEffects/ExplosiveArrows.cs
+++ b/EpicLoot/src/Magic/MagicItemEffects/ExplosiveArrows.cs
@@ -19,11 +19,11 @@ namespace EpicLoot.MagicItemEffects
                 new CodeMatch(OpCodes.Ldfld, AccessTools.Field(typeof(Attack), nameof(Attack.m_weapon))),
                 new CodeMatch(OpCodes.Ldloc_S),
                 new CodeMatch(OpCodes.Stfld, AccessTools.Field(typeof(ItemDrop.ItemData), nameof(ItemDrop.ItemData.m_lastProjectile))))
+                .ThrowIfNotMatch("Unable to patch FireProjectileBurst for Exploding Arrows.")
                 .Advance(3).InsertAndAdvance(
                 new CodeInstruction(OpCodes.Ldloc_S, (byte)20),
                 new CodeInstruction(OpCodes.Ldarg_0),
-                Transpilers.EmitDelegate(UpdateProjectileHit))
-                .ThrowIfNotMatch("Unable to patch FireProjectileBurst for Exploding Arrows.");
+                Transpilers.EmitDelegate(UpdateProjectileHit));
             return codeMatcher.Instructions();
         }
 
@@ -49,14 +49,15 @@ namespace EpicLoot.MagicItemEffects
         {
             CodeMatcher codeMatcher = new CodeMatcher(instructions);
             codeMatcher.MatchStartForward(
-                new CodeMatch(OpCodes.Ldarg_0), // Projectile instance
-                new CodeMatch(OpCodes.Ldc_I4_1),
-                new CodeMatch(OpCodes.Stfld, AccessTools.Field(typeof(Projectile), nameof(Projectile.m_didHit))))
-                .Advance(3).InsertAndAdvance(
-                new CodeInstruction(OpCodes.Ldarg_2), // Vector3 hitPoint
-                new CodeInstruction(OpCodes.Ldarg_0), // Projectile instance
-                Transpilers.EmitDelegate(SpawnExplosiveArrowOnHit))
-                .ThrowIfNotMatch("Unable to patch OnHit for Exploding Arrows.");
+                    new CodeMatch(OpCodes.Ldarg_0), // Projectile instance
+                    new CodeMatch(OpCodes.Ldc_I4_1),
+                    new CodeMatch(OpCodes.Stfld, AccessTools.Field(typeof(Projectile), nameof(Projectile.m_didHit))))
+                .ThrowIfNotMatch("Unable to patch OnHit for Exploding Arrows.")
+                .Advance(3)
+                .InsertAndAdvance(
+                    new CodeInstruction(OpCodes.Ldarg_2), // Vector3 hitPoint
+                    new CodeInstruction(OpCodes.Ldarg_0), // Projectile instance
+                    Transpilers.EmitDelegate(SpawnExplosiveArrowOnHit));
             return codeMatcher.Instructions();
         }
 

--- a/EpicLoot/src/Magic/MagicItemEffects/ModifyMeads.cs
+++ b/EpicLoot/src/Magic/MagicItemEffects/ModifyMeads.cs
@@ -18,18 +18,18 @@ namespace EpicLoot.Magic.MagicItemEffects
         {
             CodeMatcher codeMatcher = new CodeMatcher(instructions);
             codeMatcher.MatchStartForward(
-                new CodeMatch(OpCodes.Ldfld, AccessTools.Field(typeof(ItemDrop.ItemData.SharedData),
-                    nameof(ItemDrop.ItemData.m_shared.m_consumeStatusEffect))),
-                new CodeMatch(OpCodes.Ldc_I4_1),
-                new CodeMatch(OpCodes.Ldc_I4_0),
-                new CodeMatch(OpCodes.Ldc_R4),
-                new CodeMatch(OpCodes.Callvirt, AccessTools.Method(typeof(SEMan), nameof(SEMan.AddStatusEffect), new System.Type[]
-                {
-                    typeof(StatusEffect), typeof(bool), typeof(int), typeof(float)
-                })))
-                .Advance(1).InsertAndAdvance(
-                Transpilers.EmitDelegate(ModifyMead))
-                .ThrowIfNotMatch("Unable to patch Player.ConsumeItem for Instant Meads.");
+                    new CodeMatch(OpCodes.Ldfld, AccessTools.Field(typeof(ItemDrop.ItemData.SharedData),
+                        nameof(ItemDrop.ItemData.m_shared.m_consumeStatusEffect))),
+                    new CodeMatch(OpCodes.Ldc_I4_1),
+                    new CodeMatch(OpCodes.Ldc_I4_0),
+                    new CodeMatch(OpCodes.Ldc_R4),
+                    new CodeMatch(OpCodes.Callvirt, AccessTools.Method(typeof(SEMan), nameof(SEMan.AddStatusEffect), new System.Type[]
+                    {
+                        typeof(StatusEffect), typeof(bool), typeof(int), typeof(float)
+                    })))
+                .ThrowIfNotMatch("Unable to patch Player.ConsumeItem for Instant Meads.")
+                .Advance(1)
+                .InsertAndAdvance(Transpilers.EmitDelegate(ModifyMead));
             return codeMatcher.Instructions();
         }
 

--- a/EpicLoot/src/Magic/MagicItemEffects/ModifyPlayerRegen.cs
+++ b/EpicLoot/src/Magic/MagicItemEffects/ModifyPlayerRegen.cs
@@ -1,4 +1,5 @@
 ﻿using HarmonyLib;
+using System;
 using System.Collections.Generic;
 using System.Reflection.Emit;
 
@@ -9,24 +10,64 @@ public static class ModifyPlayerRegen
     [HarmonyPatch]
     private static class SEMan_ModifyRegen_Patches
     {
+        [HarmonyEmitIL("dumps")]
         [HarmonyTranspiler]
         [HarmonyPatch(typeof(Player), nameof(Player.UpdateFood))]
         private static IEnumerable<CodeInstruction> ModifyHealthRegen_Transpiler(IEnumerable<CodeInstruction> instructions)
         {
-            CodeMatcher codeMatcher = new CodeMatcher(instructions);
-            codeMatcher.MatchStartForward(
-                new CodeMatch(OpCodes.Ldloc_S),
-                new CodeMatch(OpCodes.Ldloc_S),
-                new CodeMatch(OpCodes.Mul),
-                new CodeMatch(OpCodes.Stloc_S),
-                new CodeMatch(OpCodes.Ldarg_0),
-                new CodeMatch(OpCodes.Ldloc_S),
-                new CodeMatch(OpCodes.Ldc_I4_1),
-                new CodeMatch(OpCodes.Call, AccessTools.Method(typeof(Character), nameof(Character.Heal))))
-                .Advance(1).InsertAndAdvance(
-                Transpilers.EmitDelegate(AddHealthTicks))
-                .ThrowIfNotMatch("Unable to patch Player.UpdateFood for AddHealthRegen effect.");
-            return codeMatcher.Instructions();
+            try
+            {
+                CodeMatcher codeMatcher = new CodeMatcher(instructions);
+                codeMatcher.MatchStartForward(
+                        new CodeMatch(OpCodes.Ldloc_S),
+                        new CodeMatch(OpCodes.Ldloc_S),
+                        new CodeMatch(OpCodes.Mul),
+                        new CodeMatch(OpCodes.Stloc_S),
+                        new CodeMatch(OpCodes.Ldarg_0),
+                        new CodeMatch(OpCodes.Ldloc_S),
+                        new CodeMatch(OpCodes.Ldc_I4_1),
+                        new CodeMatch(OpCodes.Call, AccessTools.Method(typeof(Character), nameof(Character.Heal))))
+                    .ThrowIfNotMatch("Unable to patch vanilla pattern of Player.UpdateFood for AddHealthRegen effect. " +
+                        "Trying alternative pattern match...")
+                    .Advance(1)
+                    .InsertAndAdvance(Transpilers.EmitDelegate(AddHealthTicks));
+
+                    return codeMatcher.Instructions();
+            }
+            catch (Exception e)
+            {
+                EpicLoot.Log(e.Message);
+            }
+
+            // Steady Regeneration mod support
+            try
+            {
+                CodeMatcher codeMatcher = new CodeMatcher(instructions);
+                codeMatcher.MatchStartForward(
+                        new CodeMatch(OpCodes.Ldloc_S),
+                        new CodeMatch(OpCodes.Ldloc_S),
+                        new CodeMatch(OpCodes.Mul),
+                        new CodeMatch(OpCodes.Stloc_S),
+                        new CodeMatch(OpCodes.Ldarg_0),
+                        new CodeMatch(OpCodes.Ldloc_S),
+                        new CodeMatch(OpCodes.Ldc_R4),
+                        new CodeMatch(OpCodes.Mul),
+                        new CodeMatch(OpCodes.Ldc_I4_0),
+                        new CodeMatch(OpCodes.Call, AccessTools.Method(typeof(Character), nameof(Character.Heal))))
+                    .ThrowIfNotMatch("SteadyRegeneration mod support patch: Unable to patch Player.UpdateFood for AddHealthRegen effect.")
+                    .Advance(1)
+                    .InsertAndAdvance(Transpilers.EmitDelegate(AddHealthTicks));
+
+                return codeMatcher.Instructions();
+            }
+            catch (Exception e)
+            {
+                EpicLoot.Log(e.Message);
+            }
+
+            EpicLoot.LogErrorForce("Mod conflict detected! Modify Health Regen effects WILL NOT WORK!");
+
+            return instructions;
         }
 
         private static float AddHealthTicks(float value)

--- a/EpicLoot/src/Magic/MagicItemEffects/MultiShot.cs
+++ b/EpicLoot/src/Magic/MagicItemEffects/MultiShot.cs
@@ -161,14 +161,15 @@ namespace EpicLoot.MagicItemEffects
         {
             CodeMatcher codeMatcher = new CodeMatcher(instructions);
             codeMatcher.MatchStartForward(
-                new CodeMatch(OpCodes.Callvirt),
-                new CodeMatch(OpCodes.Ldarg_1),
-                new CodeMatch(OpCodes.Ldind_Ref),
-                new CodeMatch(OpCodes.Ldc_I4_1),
-                new CodeMatch(OpCodes.Callvirt)
-                ).Advance(4).RemoveInstructions(1).InsertAndAdvance(
-                Transpilers.EmitDelegate(CustomRemoveItem)
-                ).ThrowIfNotMatch("Unable to ammo removal for tripleshot.");
+                    new CodeMatch(OpCodes.Callvirt),
+                    new CodeMatch(OpCodes.Ldarg_1),
+                    new CodeMatch(OpCodes.Ldind_Ref),
+                    new CodeMatch(OpCodes.Ldc_I4_1),
+                    new CodeMatch(OpCodes.Callvirt))
+                .ThrowIfNotMatch("Unable to ammo removal for tripleshot.")
+                .Advance(4)
+                .RemoveInstructions(1)
+                .InsertAndAdvance(Transpilers.EmitDelegate(CustomRemoveItem));
             return codeMatcher.Instructions();
         }
 

--- a/EpicLoot/thunderstore/manifest.json
+++ b/EpicLoot/thunderstore/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "EpicLoot",
-  "version_number": "0.12.7",
+  "version_number": "0.12.8",
   "website_url": "https://discord.gg/ZNhYeavv3C",
   "description": "Adds loot drops, magic items, and enchanting to Valheim.",
   "dependencies": [


### PR DESCRIPTION
* Many configuration tweaks. Delete and regenerate the json files specified to get the changes for each or grab the fixes manually if you have made changes:
* adventuredata.json, enchantcosts.json: Added default configurations for "None" and "Misc" item types. This will fix support for some modded items like "Bows Before Hoes" quivers.
  * If you see other items with no costs in the enchanting table it is related to this issue. Please report issues only after refreshing your base configurations.
* enchantcosts.json: 
  * New field IsUnidentified for DisenchantProducts to better distinguish the configuration for these items with the previous change.
  * Changed identify CostByRarity blackforest cost to Bronze to match other items.
* loottables.json: Fixed a bug with the auto sorter misclassifying items if their first crafting material was lower tier than the rest.
* itemsorter.json:
  * Added Ooze to Swamp BiomeMaterials.
  * Fixed Plains having the bonemass boss key rather than defeated_goblinking.
* Removed throwable bombs showing up as a possible unidentifiable item roll.
* Added mod compatibility for Steady Regeneration (broke in 0.12.6).