### PR TITLE
Epic loot 12.9

### DIFF
--- a/EpicLoot/CHANGELOG.md
+++ b/EpicLoot/CHANGELOG.md
@@ -1,9 +1,14 @@
+## Version 0.12.9
+
+* Fixed issue with empty IdentifyCosts throwing an error.
+* Added compatibility with Guilds mod that broke buying things in the custom trader menu.
+
 ## Version 0.12.8
 
 * Many configuration tweaks. Delete and regenerate the json files specified to get the changes for each or grab the fixes manually if you have made changes:
 * adventuredata.json, enchantcosts.json: Added default configurations for "None" and "Misc" item types. This will fix support for some modded items like "Bows Before Hoes" quivers.
   * If you see other items with no costs in the enchanting table it is related to this issue. Please report issues only after refreshing your base configurations.
-* enchantcosts.json: 
+* enchantcosts.json:
   * New field IsUnidentified for DisenchantProducts to better distinguish the configuration for these items with the previous change.
   * Changed identify CostByRarity blackforest cost to Bronze to match other items.
 * loottables.json: Fixed a bug with the auto sorter misclassifying items if their first crafting material was lower tier than the rest.

--- a/EpicLoot/EpicLoot.cs
+++ b/EpicLoot/EpicLoot.cs
@@ -37,7 +37,7 @@ public sealed class EpicLoot : BaseUnityPlugin
 {
     public const string PluginId = "randyknapp.mods.epicloot";
     public const string DisplayName = "Epic Loot";
-    public const string Version = "0.12.8";
+    public const string Version = "0.12.9";
 
     private static string ConfigFileName = PluginId + ".cfg";
     private static string ConfigFileFullPath = BepInEx.Paths.ConfigPath + Path.DirectorySeparatorChar + ConfigFileName;

--- a/EpicLoot/Properties/AssemblyInfo.cs
+++ b/EpicLoot/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("0.12.8")]
-[assembly: AssemblyFileVersion("0.12.8")]
+[assembly: AssemblyVersion("0.12.9")]
+[assembly: AssemblyFileVersion("0.12.9")]

--- a/EpicLoot/src/Adventure/MerchantPanel.cs
+++ b/EpicLoot/src/Adventure/MerchantPanel.cs
@@ -310,7 +310,7 @@ namespace EpicLoot.Adventure
         private static string GetRefreshTimeTooltip(int refreshInterval)
         {
             var message = refreshInterval > 1 ?
-                Localization.instance.Localize("$mod_epicloot_merchant_refreshdays", refreshInterval.ToString()) : 
+                Localization.instance.Localize("$mod_epicloot_merchant_refreshdays", refreshInterval.ToString()) :
                 "$mod_epicloot_merchant_refreshday";
             return $"<color=#add8e6ff>{message}</color>";
         }

--- a/EpicLoot/src/Adventure/MerchantPanel.cs
+++ b/EpicLoot/src/Adventure/MerchantPanel.cs
@@ -303,7 +303,7 @@ namespace EpicLoot.Adventure
                 InventoryManagement.Instance.RemoveItem(GetGoldBountyTokenName(), listItem.ItemInfo.Cost.GoldBountyTokens);
             }
 
-            StoreGui.instance.m_trader.OnBought(null);
+            StoreGui.instance.m_trader.OnBought(new Trader.TradeItem { m_price = 0 });
             StoreGui.instance.m_buyEffects.Create(player.transform.position, Quaternion.identity);
         }
 

--- a/EpicLoot/src/Adventure/feature/BountiesListPanel.cs
+++ b/EpicLoot/src/Adventure/feature/BountiesListPanel.cs
@@ -67,7 +67,7 @@ namespace EpicLoot.Adventure.Feature
 
                         if (StoreGui.instance.m_trader != null)
                         {
-                            StoreGui.instance.m_trader.OnBought(null);
+                            StoreGui.instance.m_trader.OnBought(new Trader.TradeItem { m_price = 0 });
                         }
 
                         StoreGui.instance.m_buyEffects?.Create(player.transform.position, Quaternion.identity);
@@ -164,7 +164,7 @@ namespace EpicLoot.Adventure.Feature
 
                 _merchantPanel.RefreshAll();
 
-                StoreGui.instance.m_trader.OnBought(null);
+                StoreGui.instance.m_trader.OnBought(new Trader.TradeItem { m_price = 0 });
                 StoreGui.instance.m_buyEffects.Create(player.transform.position, Quaternion.identity);
             }
         }

--- a/EpicLoot/src/Adventure/feature/TreasureMapListPanel.cs
+++ b/EpicLoot/src/Adventure/feature/TreasureMapListPanel.cs
@@ -76,7 +76,7 @@ namespace EpicLoot.Adventure.Feature
                 
                 if (StoreGui.instance.m_trader != null)
                 {
-                    StoreGui.instance.m_trader.OnBought(null);
+                    StoreGui.instance.m_trader.OnBought(new Trader.TradeItem { m_price = 0 });
                 }
 
                 StoreGui.instance.m_buyEffects?.Create(Player.m_localPlayer.transform.position, Quaternion.identity);

--- a/EpicLoot/src/Crafting/EnchantCostsHelper.cs
+++ b/EpicLoot/src/Crafting/EnchantCostsHelper.cs
@@ -122,7 +122,6 @@ namespace EpicLoot.Crafting
             if (Config.IdentifyCosts.TryGetValue(biome, out IdentifyCostConfig biomeConfig) &&
                 biomeConfig.CostByRarity.TryGetValue(rarity, out List<ItemAmountConfig> rarityCosts))
             {
-                EpicLoot.Log($"The {rarityCosts[0].Item} amount is {rarityCosts[0].Amount}");
                 totalCost.AddRange(rarityCosts);
             }
             else

--- a/EpicLoot/src/Loot/LootRoller.cs
+++ b/EpicLoot/src/Loot/LootRoller.cs
@@ -196,12 +196,11 @@ namespace EpicLoot
         public static Dictionary<string,float> GetLootTableChances(Vector3 location, List<LootTable> LootTables)
         {
             Dictionary<string, float> results = new Dictionary<string, float>();
-            EpicLoot.Log($"Checking {LootTables.Count} loot tables");
+
             foreach(LootTable lt in LootTables)
             {
                 foreach(LootDrop ld in lt.Loot)
                 {
-                    EpicLoot.Log($"Checking {ld.Item} is itemset? {ItemSets.ContainsKey(ld.Item)}");
                     if (ItemSets.ContainsKey(ld.Item))
                     {
                         ItemSets[ld.Item].Loot.ToList().ForEach(x =>
@@ -227,7 +226,7 @@ namespace EpicLoot
                     }
                 }
             }
-            EpicLoot.Log($"Loot table contains {results.Count} items");
+
             return results;
         }
 

--- a/EpicLoot/thunderstore/manifest.json
+++ b/EpicLoot/thunderstore/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "EpicLoot",
-  "version_number": "0.12.8",
+  "version_number": "0.12.9",
   "website_url": "https://discord.gg/ZNhYeavv3C",
   "description": "Adds loot drops, magic items, and enchanting to Valheim.",
   "dependencies": [


### PR DESCRIPTION
* Fixed issue with empty IdentifyCosts throwing an error.
* Added compatibility with Guilds mod that broke buying things in the custom trader menu.