### PR TITLE
Minor code-cleanup for smaller Harmony patches.

### DIFF
--- a/EpicLoot/src/Crafting/ItemDrop_Patch.cs
+++ b/EpicLoot/src/Crafting/ItemDrop_Patch.cs
@@ -1,73 +1,77 @@
-﻿using EpicLoot.Data;
-using EpicLoot.LootBeams;
+﻿namespace EpicLoot.Crafting;
+
+using global::EpicLoot.Data;
+using global::EpicLoot.LootBeams;
 using HarmonyLib;
 using UnityEngine;
 
-namespace EpicLoot.Crafting
+[HarmonyPatch(typeof(ItemDrop), nameof(ItemDrop.Awake))]
+static class ItemDrop_Awake_Patch
 {
-    [HarmonyPatch(typeof(ItemDrop), nameof(ItemDrop.Awake))]
-    public static class ItemDrop_Awake_Patch
+    static void Postfix(ItemDrop __instance)
     {
-        public static void Postfix(ItemDrop __instance)
+        bool isMagic = __instance.m_itemData.IsMagicCraftingMaterial();
+        bool isRunestone = __instance.m_itemData.IsRunestone();
+        bool isUnidentified = __instance.m_itemData.IsUnidentified();
+
+        if (isMagic || isRunestone || isUnidentified)
         {
-            bool isMagic = __instance.m_itemData.IsMagicCraftingMaterial();
-            bool isRunestone = __instance.m_itemData.IsRunestone();
-            bool isUnidentified = __instance.m_itemData.IsUnidentified();
+            Transform particleContainer = __instance.transform.Find("Particles");
 
-            if (isMagic || isRunestone || isUnidentified)
+            if (particleContainer)
             {
-                var particleContainer = __instance.transform.Find("Particles");
-                if (particleContainer != null)
-                {
-                    particleContainer.gameObject.AddComponent<AlwaysPointUp>();
-                }
+                particleContainer.gameObject.AddComponent<AlwaysPointUp>();
+            }
 
-                ItemRarity rarity = isRunestone ? __instance.m_itemData.GetRunestoneRarity() :
-                    __instance.m_itemData.GetCraftingMaterialRarity();
-                var magicColor = EpicLoot.GetRarityColor(rarity);
-                var variant = isRunestone ? 0 : EpicLoot.GetRarityIconIndex(rarity);
+            ItemRarity rarity = isRunestone
+                ? __instance.m_itemData.GetRunestoneRarity()
+                : __instance.m_itemData.GetCraftingMaterialRarity();
 
-                // Ensure unidenfitied items are loaded back up if they somehow become non-magical
-                MagicItemComponent mi = __instance.m_itemData.Data().GetOrCreate<MagicItemComponent>();
-                if (isUnidentified && mi.MagicItem == null)
-                {
-                    mi.SetMagicItem(new MagicItem
+            string magicColor = EpicLoot.GetRarityColor(rarity);
+            int variant = isRunestone ? 0 : EpicLoot.GetRarityIconIndex(rarity);
+
+            // Ensure unidenfitied items are loaded back up if they somehow become non-magical
+            MagicItemComponent magicItem = __instance.m_itemData.Data().GetOrCreate<MagicItemComponent>();
+
+            if (isUnidentified && magicItem.MagicItem == null)
+            {
+                magicItem.SetMagicItem(
+                    new MagicItem
                     {
                         Rarity = rarity,
                         IsUnidentified = true,
                     });
 
-                    mi.Save();
-                }
-
-                if (ColorUtility.TryParseHtmlString(magicColor, out var rgbaColor))
-                {
-                    __instance.gameObject.AddComponent<BeamColorSetter>().SetColor(rgbaColor);
-                }
-
-                if (isUnidentified)
-                {
-                    variant = 0;
-                }
-
-                __instance.m_itemData.m_variant = variant;
+                magicItem.Save();
             }
+
+            if (ColorUtility.TryParseHtmlString(magicColor, out Color rgbaColor))
+            {
+                __instance.gameObject.AddComponent<BeamColorSetter>().SetColor(rgbaColor);
+            }
+
+            if (isUnidentified)
+            {
+                variant = 0;
+            }
+
+            __instance.m_itemData.m_variant = variant;
         }
     }
+}
 
-    [HarmonyPatch(typeof(Inventory), nameof(Inventory.Load))]
-    public static class Inventory_Load_Patch
+[HarmonyPatch(typeof(Inventory), nameof(Inventory.Load))]
+static class Inventory_Load_Patch
+{
+    static void Postfix(Inventory __instance)
     {
-        public static void Postfix(Inventory __instance)
+        foreach (ItemDrop.ItemData item in __instance.m_inventory)
         {
-            foreach (var item in __instance.m_inventory)
+            if (item.IsMagicCraftingMaterial())
             {
-                if (item.IsMagicCraftingMaterial())
-                {
-                    var rarity = item.GetCraftingMaterialRarity();
-                    var variant = EpicLoot.GetRarityIconIndex(rarity);
-                    item.m_variant = variant;
-                }
+                ItemRarity rarity = item.GetCraftingMaterialRarity();
+                int variant = EpicLoot.GetRarityIconIndex(rarity);
+                item.m_variant = variant;
             }
         }
     }

--- a/EpicLoot/src/Crafting/Player_Patch.cs
+++ b/EpicLoot/src/Crafting/Player_Patch.cs
@@ -1,18 +1,18 @@
-﻿using HarmonyLib;
+﻿namespace EpicLoot.Crafting;
 
-namespace EpicLoot.Crafting
+using HarmonyLib;
+
+[HarmonyPatch(typeof(Player), nameof(Player.AddKnownItem))]
+static class Player_AddKnownItem_Patch
 {
-    [HarmonyPatch(typeof(Player), nameof(Player.AddKnownItem))]
-    public static class Player_AddKnownItem_Patch
+    static bool Prefix(ItemDrop.ItemData item)
     {
-        public static bool Prefix(ItemDrop.ItemData item)
+        if (item.IsMagicCraftingMaterial())
         {
-            if (item.IsMagicCraftingMaterial())
-            {
-                var variant = EpicLoot.GetRarityIconIndex(item.GetCraftingMaterialRarity());
-                item.m_variant = variant;
-            }
-            return true;
+            int variant = EpicLoot.GetRarityIconIndex(item.GetCraftingMaterialRarity());
+            item.m_variant = variant;
         }
+
+        return true;
     }
 }

--- a/EpicLoot/src/GamePatches/Attack_Patch.cs
+++ b/EpicLoot/src/GamePatches/Attack_Patch.cs
@@ -1,25 +1,25 @@
-﻿using HarmonyLib;
+﻿namespace EpicLoot;
 
-namespace EpicLoot
+using HarmonyLib;
+
+[HarmonyPatch]
+static class Attack_Patch
 {
-    [HarmonyPatch]
-    public static class Attack_Patch
+    // TODO: Move this to a manager/controller/utility as this is referenced in multiple patches and mod logic.
+    public static Attack ActiveAttack = null;
+
+    [HarmonyPatch(typeof(Attack), nameof(Attack.DoMeleeAttack))]
+    [HarmonyPrefix]
+    [HarmonyPriority(Priority.Last)]
+    static void Attack_DoMeleeAttack_Prefix(Attack __instance)
     {
-        public static Attack ActiveAttack = null;
+        ActiveAttack = __instance;
+    }
 
-        [HarmonyPatch(typeof(Attack), nameof(Attack.DoMeleeAttack))]
-        [HarmonyPrefix]
-        [HarmonyPriority(Priority.Last)]
-        public static void Attack_DoMeleeAttack_Prefix(Attack __instance)
-        {
-            ActiveAttack = __instance;
-        }
-
-        [HarmonyPatch(typeof(Attack), nameof(Attack.DoMeleeAttack))]
-        [HarmonyPostfix]
-        public static void Attack_DoMeleeAttack_Postfix()
-        {
-            ActiveAttack = null;
-        }
+    [HarmonyPatch(typeof(Attack), nameof(Attack.DoMeleeAttack))]
+    [HarmonyPostfix]
+    static void Attack_DoMeleeAttack_Postfix()
+    {
+        ActiveAttack = null;
     }
 }

--- a/EpicLoot/src/GamePatches/Container_Patch.cs
+++ b/EpicLoot/src/GamePatches/Container_Patch.cs
@@ -1,35 +1,43 @@
-﻿using HarmonyLib;
+﻿namespace EpicLoot;
+
+using HarmonyLib;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace EpicLoot
+[HarmonyPatch(typeof(Container), nameof(Container.AddDefaultItems))]
+static class Container_AddDefaultItems_Patch
 {
-    [HarmonyPatch(typeof(Container), nameof(Container.AddDefaultItems))]
-    public static class Container_AddDefaultItems_Patch
+    static void Postfix(Container __instance)
     {
-        public static void Postfix(Container __instance)
+        if (!__instance || !__instance.m_piece)
         {
-            if (__instance == null || __instance.m_piece == null)
-            {
-                return;
-            }
+            return;
+        }
 
-            string containerName = __instance.m_piece.name.Replace("(Clone)", "").Trim();
-            List<LootTable> lootTables = LootRoller.GetLootTable(containerName);
-            if (lootTables != null && lootTables.Count > 0)
-            {
-                List<ItemDrop.ItemData> items =
-                    LootRoller.RollLootTable(lootTables, 1, __instance.m_piece.name, __instance.transform.position);
-                EpicLoot.Log($"Rolling on loot table: {containerName}, " +
-                    $"spawned {items.Count} items at drop point({__instance.transform.position.ToString("0")}).");
-                foreach (ItemDrop.ItemData item in items)
-                {
-                    __instance.m_inventory.AddItem(item);
-                    EpicLoot.Log($"  - {item.m_shared.m_name}" + (item.IsMagic() ?
-                        $": {string.Join(", ", item.GetMagicItem().Effects.Select(x => x.EffectType.ToString()))}" :
-                        ""));
-                }
-            }
+        string containerName = __instance.m_piece.name.Replace("(Clone)", "").Trim();
+        List<LootTable> lootTables = LootRoller.GetLootTable(containerName);
+
+        if (lootTables == null || lootTables.Count <= 0)
+        {
+            return;
+        }
+
+        List<ItemDrop.ItemData> items =
+            LootRoller.RollLootTable(lootTables, 1, __instance.m_piece.name, __instance.transform.position);
+
+        EpicLoot.Log(
+            $"Rolling on loot table: {containerName}, "
+                + $"spawned {items.Count} items at drop point({__instance.transform.position:0}).");
+
+        foreach (ItemDrop.ItemData item in items)
+        {
+            __instance.m_inventory.AddItem(item);
+
+            EpicLoot.Log(               
+                $"  - {item.m_shared.m_name}"
+                    + (item.IsMagic()
+                        ? $": {string.Join(", ", item.GetMagicItem().Effects.Select(x => x.EffectType.ToString()))}"
+                        : string.Empty));
         }
     }
 }

--- a/EpicLoot/src/GamePatches/GameCamera_Patch.cs
+++ b/EpicLoot/src/GamePatches/GameCamera_Patch.cs
@@ -1,21 +1,23 @@
-﻿using HarmonyLib;
+﻿namespace EpicLoot;
 
-namespace EpicLoot
+using HarmonyLib;
+
+// TODO: Patch was added in 2021 and overrides free-fly to 30 FPS; check if this can be removed.
+[HarmonyPatch(typeof(GameCamera), nameof(GameCamera.UpdateCamera))]
+static class GameCamera_UpdateCamera_Patch
 {
-    [HarmonyPatch(typeof(GameCamera), nameof(GameCamera.UpdateCamera))]
-    public static class GameCamera_UpdateCamera_Patch
-    {
-        public static bool Prefix(GameCamera __instance)
-        {
-            if (__instance.m_freeFly)
-            {
-                const float dt = 1.0f / 30.0f;
-                __instance.UpdateFreeFly(dt);
-                __instance.UpdateCameraShake(dt);
-                return false;
-            }
+    const float _dt = 1f / 30f;
 
-            return true;
+    static bool Prefix(GameCamera __instance)
+    {
+        if (__instance.m_freeFly)
+        {
+            __instance.UpdateFreeFly(_dt);
+            __instance.UpdateCameraShake(_dt);
+
+            return false;
         }
+
+        return true;
     }
 }

--- a/EpicLoot/src/GamePatches/Humanoid_Patch.cs
+++ b/EpicLoot/src/GamePatches/Humanoid_Patch.cs
@@ -1,40 +1,43 @@
-﻿using HarmonyLib;
+﻿namespace EpicLoot;
 
-namespace EpicLoot
+using HarmonyLib;
+using UnityEngine;
+
+[HarmonyPatch(typeof(Humanoid))]
+static class Humanoid_Patch
 {
-    [HarmonyPatch(typeof(Humanoid))]
-    public static class Humanoid_Patch
+    // Handle ItemDrop.ItemData that have null m_dropPrefab values to prevent NRE in method.
+    // TODO: Validate if this is needed, or can be fixed in a better way.
+    [HarmonyPatch(nameof(Humanoid.SetupVisEquipment))]
+    [HarmonyPrefix]
+    static void SetupVisEquipment_Prefix(Humanoid __instance, VisEquipment visEq, bool isRagdoll)
     {
-        // Handle ItemDrop.ItemData that have null m_dropPrefab values to prevent NRE in method.
-        // TODO: Validate if this is needed, or can be fixed in a better way.
-        [HarmonyPatch(nameof(Humanoid.SetupVisEquipment))]
-        [HarmonyPrefix]
-        public static void SetupVisEquipment_Prefix(Humanoid __instance, VisEquipment visEq, bool isRagdoll)
-        {
-            if (EpicAssets.DummyPrefab() == null)
-            {
-                EpicLoot.LogWarning("Unable to find empty object, may cause unexpected errors for Humanoid.SetupVisEquipment method.");
-                return;
-            }
+        GameObject dummyPrefab = EpicAssets.DummyPrefab();
 
-            AssignEmptyToNull(ref __instance.m_leftItem);
-            AssignEmptyToNull(ref __instance.m_rightItem);
-            AssignEmptyToNull(ref __instance.m_hiddenLeftItem);
-            AssignEmptyToNull(ref __instance.m_hiddenRightItem);
-            AssignEmptyToNull(ref __instance.m_chestItem);
-            AssignEmptyToNull(ref __instance.m_legItem);
-            AssignEmptyToNull(ref __instance.m_helmetItem);
-            AssignEmptyToNull(ref __instance.m_shoulderItem);
-            AssignEmptyToNull(ref __instance.m_utilityItem);
-            AssignEmptyToNull(ref __instance.m_trinketItem);
+        if (!dummyPrefab)
+        {
+            EpicLoot.LogWarning(
+                "Unable to find empty object, may cause unexpected errors for Humanoid.SetupVisEquipment method.");
+            return;
         }
 
-        private static void AssignEmptyToNull(ref ItemDrop.ItemData data)
+        AssignEmptyToNull(ref __instance.m_leftItem, dummyPrefab);
+        AssignEmptyToNull(ref __instance.m_rightItem, dummyPrefab);
+        AssignEmptyToNull(ref __instance.m_hiddenLeftItem, dummyPrefab);
+        AssignEmptyToNull(ref __instance.m_hiddenRightItem, dummyPrefab);
+        AssignEmptyToNull(ref __instance.m_chestItem, dummyPrefab);
+        AssignEmptyToNull(ref __instance.m_legItem, dummyPrefab);
+        AssignEmptyToNull(ref __instance.m_helmetItem, dummyPrefab);
+        AssignEmptyToNull(ref __instance.m_shoulderItem, dummyPrefab);
+        AssignEmptyToNull(ref __instance.m_utilityItem, dummyPrefab);
+        AssignEmptyToNull(ref __instance.m_trinketItem, dummyPrefab);
+    }
+
+    private static void AssignEmptyToNull(ref ItemDrop.ItemData data, GameObject dummyPrefab)
+    {
+        if (data != null && !data.m_dropPrefab)
         {
-            if (data != null && data.m_dropPrefab == null)
-            {
-                data.m_dropPrefab = EpicAssets.DummyPrefab();
-            }
+            data.m_dropPrefab = dummyPrefab;
         }
     }
 }

--- a/EpicLoot/src/GamePatches/ItemDrop_Patch.cs
+++ b/EpicLoot/src/GamePatches/ItemDrop_Patch.cs
@@ -1,59 +1,58 @@
-﻿using EpicLoot.Crafting;
-using EpicLoot.LootBeams;
+﻿namespace EpicLoot;
+
+using global::EpicLoot.Crafting;
+using global::EpicLoot.LootBeams;
 using HarmonyLib;
 
-namespace EpicLoot
+[HarmonyPatch(typeof(ItemDrop), nameof(ItemDrop.Awake))]
+static class ItemDrop_Awake_Patch
 {
-    [HarmonyPatch(typeof(ItemDrop), nameof(ItemDrop.Awake))]
-    public static class ItemDrop_Awake_Patch
+    static void Postfix(ItemDrop __instance)
     {
-        public static void Postfix(ItemDrop __instance)
+        if (__instance.m_itemData == null)
         {
-            if (__instance.m_itemData == null)
-            {
-                return;
-            }
+            return;
+        }
 
-            __instance.m_itemData.InitializeCustomData();
+        __instance.m_itemData.InitializeCustomData();
 
-            if (__instance.gameObject.GetComponent<LootBeam>() == null)
-            {
-                __instance.gameObject.AddComponent<LootBeam>();
-            }
+        if (!__instance.TryGetComponent(out LootBeam _))
+        {
+            __instance.gameObject.AddComponent<LootBeam>();
         }
     }
+}
 
-    [HarmonyPatch(typeof(Inventory), nameof(Inventory.Load))]
-    public static class Inventory_Load_Patch
+[HarmonyPatch(typeof(Inventory), nameof(Inventory.Load))]
+static class Inventory_Load_Patch
+{
+    static void Postfix(Inventory __instance)
     {
-        public static void Postfix(Inventory __instance)
+        foreach (ItemDrop.ItemData itemData in __instance.m_inventory)
         {
-            foreach (ItemDrop.ItemData itemData in __instance.m_inventory)
+            if (itemData.IsMagicCraftingMaterial())
             {
-                if (itemData.IsMagicCraftingMaterial())
-                {
-                    itemData.CreateMagicItem();
-                }
-
-                itemData.InitializeCustomData();
+                itemData.CreateMagicItem();
             }
+
+            itemData.InitializeCustomData();
         }
     }
+}
 
-    [HarmonyPatch(typeof(Container), nameof(Container.Load))]
-    public static class Container_Load_Patch
+[HarmonyPatch(typeof(Container), nameof(Container.Load))]
+static class Container_Load_Patch
+{
+    static void Postfix(Container __instance)
     {
-        public static void Postfix(Container __instance)
+        foreach (ItemDrop.ItemData itemData in __instance.m_inventory.m_inventory)
         {
-            foreach (ItemDrop.ItemData itemData in __instance.m_inventory.m_inventory)
+            if (itemData.IsMagicCraftingMaterial())
             {
-                if (itemData.IsMagicCraftingMaterial())
-                {
-                    itemData.CreateMagicItem();
-                }
-
-                itemData.InitializeCustomData();
+                itemData.CreateMagicItem();
             }
+
+            itemData.InitializeCustomData();
         }
     }
 }

--- a/EpicLoot/src/GamePatches/ZNet_Patch.cs
+++ b/EpicLoot/src/GamePatches/ZNet_Patch.cs
@@ -1,44 +1,45 @@
-﻿using EpicLoot.Adventure;
+﻿namespace EpicLoot;
+
+using global::EpicLoot.Adventure;
 using HarmonyLib;
 
-namespace EpicLoot
+[HarmonyPatch(typeof(ZNet), nameof(ZNet.Awake))]
+static class ZNetPatches
 {
-    [HarmonyPatch(typeof(ZNet), nameof(ZNet.Awake))]
-    public static class ZNetPatches
+    static void Postfix(ZNet __instance)
     {
-        public static void Postfix(ZNet __instance)
+        if (__instance.IsServer())
         {
-            if (__instance.IsServer())
-                __instance.gameObject.AddComponent<BountyManagmentSystem>();
-            
-            AdventureDataManager.Bounties.RegisterRPC(__instance.m_routedRpc);
+            __instance.gameObject.AddComponent<BountyManagmentSystem>();
         }
+        
+        AdventureDataManager.Bounties.RegisterRPC(__instance.m_routedRpc);
     }
+}
 
-    [HarmonyPatch(typeof(ZNet), nameof(ZNet.Start))]
-    public static class ZNet_Start_Patch
+[HarmonyPatch(typeof(ZNet), nameof(ZNet.Start))]
+static class ZNet_Start_Patch
+{
+    static void Postfix(ZNet __instance)
     {
-        public static void Postfix(ZNet __instance)
-        {
-            AdventureDataManager.OnZNetStart();
-        }
+        AdventureDataManager.OnZNetStart();
     }
+}
 
-    [HarmonyPatch(typeof(ZNet), nameof(ZNet.OnDestroy))]
-    public static class ZNet_OnDestroy_Patch
+[HarmonyPatch(typeof(ZNet), nameof(ZNet.OnDestroy))]
+static class ZNet_OnDestroy_Patch
+{
+    static void Postfix(ZNet __instance)
     {
-        public static void Postfix(ZNet __instance)
-        {
-            AdventureDataManager.OnZNetDestroyed();
-        }
+        AdventureDataManager.OnZNetDestroyed();
     }
+}
 
-    [HarmonyPatch(typeof(ZNet), nameof(ZNet.SaveWorld))]
-    public static class ZNet_SaveWorld_Patch
+[HarmonyPatch(typeof(ZNet), nameof(ZNet.SaveWorld))]
+static class ZNet_SaveWorld_Patch
+{
+    static void Prefix(ZNet __instance)
     {
-        public static void Prefix(ZNet __instance)
-        {
-            AdventureDataManager.OnWorldSave();
-        }
+        AdventureDataManager.OnWorldSave();
     }
 }


### PR DESCRIPTION
Notes:
* Moved to filescoped namespaces and moved the usings *into* the namespace.
* Reduced visibility for static patch classes and methods to package-private.
* Converted all `var` into explicit types.
* Other minor code-cleanup for Unity-specific quirks.

New TODOs:
* Move `Attack_Patch.ActiveAttack` into a manager/controller as it's referenced in multiple places.
* Check if `GameCamera_UpdateCamera_Patch` can be deleted.