### PR TITLE
fix: hiding of toggle container on large minimap after adventure mode is turned off

### DIFF
--- a/EpicLoot/src/Adventure/Minimap/MinimapController.cs
+++ b/EpicLoot/src/Adventure/Minimap/MinimapController.cs
@@ -19,6 +19,8 @@ public class MinimapController : MonoBehaviour
     public static readonly Dictionary<string, AreaPinInfo> BountyPins = new();
     public static bool DebugMode;
 
+    private static GameObject _epicLootToggleContainer;
+
     public virtual void Awake()
     {
         _minimap = GetComponent<Minimap>();
@@ -80,6 +82,7 @@ public class MinimapController : MonoBehaviour
         MinimapPinQueue.Clear();
         TreasureMapPins.Clear();
         BountyPins.Clear();
+        _epicLootToggleContainer = null;
     }
 
     private void SetupToggles()
@@ -113,6 +116,32 @@ public class MinimapController : MonoBehaviour
         treasureToggle.SetIcon(EpicAssets.MapIconTreasureMap);
         treasureToggle.SetGamepadKey("JoyRTrigger");
         treasureToggle.SetLabel("$mod_epicloot_merchant_treasuremaps");
+
+        _epicLootToggleContainer = container;
+        RefreshEpicLootToggleContainerVisibility();
+    }
+
+    /// <summary>
+    /// When not connected to a world, the container stays active. When connected and Adventure Mode is disabled, the container is hidden.
+    /// </summary>
+    public static void RefreshEpicLootToggleContainerVisibility()
+    {
+        if (_epicLootToggleContainer == null)
+        {
+            return;
+        }
+
+        _epicLootToggleContainer.SetActive(ShouldShowEpicLootMinimapToggleContainer());
+    }
+
+    private static bool ShouldShowEpicLootMinimapToggleContainer()
+    {
+        if (ZNet.instance == null)
+        {
+            return true;
+        }
+
+        return EpicLoot.IsAdventureModeEnabled();
     }
 
     private static void ToggleBounties(bool show)

--- a/EpicLoot/src/Adventure/Minimap/MinimapController.cs
+++ b/EpicLoot/src/Adventure/Minimap/MinimapController.cs
@@ -19,7 +19,7 @@ public class MinimapController : MonoBehaviour
     public static readonly Dictionary<string, AreaPinInfo> BountyPins = new();
     public static bool DebugMode;
 
-    private static GameObject _epicLootToggleContainer;
+    private static GameObject _adventureToggleContainer;
 
     public virtual void Awake()
     {
@@ -82,14 +82,14 @@ public class MinimapController : MonoBehaviour
         MinimapPinQueue.Clear();
         TreasureMapPins.Clear();
         BountyPins.Clear();
-        _epicLootToggleContainer = null;
+        Destroy(_adventureToggleContainer);
     }
 
     private void SetupToggles()
     {
         GameObject original = Utils.FindChild(_minimap.transform, "SharedPanel").gameObject;
         
-        GameObject container = new GameObject("EpicLoot Toggle Container");
+        GameObject container = new GameObject("AdventureToggleContainer");
         RectTransform rect = container.AddComponent<RectTransform>();
         rect.SetParent(original.transform.parent);
 
@@ -98,7 +98,7 @@ public class MinimapController : MonoBehaviour
         rect.pivot = new Vector2(0f, 1f);
         rect.sizeDelta = new Vector2(250f, 42f);
         rect.anchoredPosition = new Vector2(20f, 60f);
-        // figure out how to programmatically set this position, if needed
+        // TODO: add repositioning configuration to be compatible with other mods
 
         HorizontalLayoutGroup layout = container.AddComponent<HorizontalLayoutGroup>();
         layout.childForceExpandWidth = false;
@@ -117,30 +117,26 @@ public class MinimapController : MonoBehaviour
         treasureToggle.SetGamepadKey("JoyRTrigger");
         treasureToggle.SetLabel("$mod_epicloot_merchant_treasuremaps");
 
-        _epicLootToggleContainer = container;
-        RefreshEpicLootToggleContainerVisibility();
+        _adventureToggleContainer = container;
+        RefreshAdventureToggleContainer();
     }
 
     /// <summary>
     /// When not connected to a world, the container stays active. When connected and Adventure Mode is disabled, the container is hidden.
     /// </summary>
-    public static void RefreshEpicLootToggleContainerVisibility()
+    public static void RefreshAdventureToggleContainer()
     {
-        if (_epicLootToggleContainer == null)
+        if (_adventureToggleContainer == null)
         {
             return;
         }
 
-        _epicLootToggleContainer.SetActive(ShouldShowEpicLootMinimapToggleContainer());
+        _adventureToggleContainer.SetActive(ShowAdventureToggleContainer());
     }
 
-    private static bool ShouldShowEpicLootMinimapToggleContainer()
+    private static bool ShowAdventureToggleContainer()
     {
-        if (ZNet.instance == null)
-        {
-            return true;
-        }
-
+        // TODO: add more configuration options to hide minimap buttons as needed
         return EpicLoot.IsAdventureModeEnabled();
     }
 

--- a/EpicLoot/src/Config/ELConfig.cs
+++ b/EpicLoot/src/Config/ELConfig.cs
@@ -296,6 +296,7 @@ internal class ELConfig
         _adventureModeEnabled = BindServerConfig("Balance", "Adventure Mode Enabled", true,
             "Set to true to enable all the adventure mode features: secret stash, gambling, treasure maps, and bounties. " +
             "Set to false to disable. This will not actually remove active treasure maps or bounties from your save.");
+        _adventureModeEnabled.SettingChanged += (_, _) => MinimapController.RefreshEpicLootToggleContainerVisibility();
         _andvaranautRange = BindServerConfig("Balance", "Andvaranaut Range", 20,
             "Sets the range that Andvaranaut will activate to locate a treasure chest.");
         SetItemDropChance = BindServerConfig("Balance", "Set Item Drop Chance", 0.15f,

--- a/EpicLoot/src/Config/ELConfig.cs
+++ b/EpicLoot/src/Config/ELConfig.cs
@@ -293,10 +293,12 @@ internal class ELConfig
             "use 'Crypt Key Drop Player Range' to set the range.");
         _bossWishboneDropPlayerRange = BindServerConfig("Balance", "Wishbone Drop Player Range", 100.0f,
             "Sets the range that bosses check when dropping multiple wishbones using the OnePerPlayerNearBoss drop mode.");
+
         _adventureModeEnabled = BindServerConfig("Balance", "Adventure Mode Enabled", true,
             "Set to true to enable all the adventure mode features: secret stash, gambling, treasure maps, and bounties. " +
             "Set to false to disable. This will not actually remove active treasure maps or bounties from your save.");
-        _adventureModeEnabled.SettingChanged += (_, _) => MinimapController.RefreshEpicLootToggleContainerVisibility();
+        _adventureModeEnabled.SettingChanged += (_, _) => MinimapController.RefreshAdventureToggleContainer();
+
         _andvaranautRange = BindServerConfig("Balance", "Andvaranaut Range", 20,
             "Sets the range that Andvaranaut will activate to locate a treasure chest.");
         SetItemDropChance = BindServerConfig("Balance", "Set Item Drop Chance", 0.15f,

--- a/EpicLoot/src/GamePatches/ZNet_Patch.cs
+++ b/EpicLoot/src/GamePatches/ZNet_Patch.cs
@@ -21,6 +21,7 @@ namespace EpicLoot
         public static void Postfix(ZNet __instance)
         {
             AdventureDataManager.OnZNetStart();
+            MinimapController.RefreshEpicLootToggleContainerVisibility();
         }
     }
 
@@ -30,6 +31,7 @@ namespace EpicLoot
         public static void Postfix(ZNet __instance)
         {
             AdventureDataManager.OnZNetDestroyed();
+            MinimapController.RefreshEpicLootToggleContainerVisibility();
         }
     }
 

--- a/EpicLoot/src/GamePatches/ZNet_Patch.cs
+++ b/EpicLoot/src/GamePatches/ZNet_Patch.cs
@@ -21,7 +21,7 @@ namespace EpicLoot
         public static void Postfix(ZNet __instance)
         {
             AdventureDataManager.OnZNetStart();
-            MinimapController.RefreshEpicLootToggleContainerVisibility();
+            MinimapController.RefreshAdventureToggleContainer();
         }
     }
 
@@ -31,7 +31,7 @@ namespace EpicLoot
         public static void Postfix(ZNet __instance)
         {
             AdventureDataManager.OnZNetDestroyed();
-            MinimapController.RefreshEpicLootToggleContainerVisibility();
+            MinimapController.RefreshAdventureToggleContainer();
         }
     }
 


### PR DESCRIPTION
* Introduced a new static variable to manage the visibility of the Epic Loot toggle container on the minimap.
* Implemented methods to refresh the toggle container's visibility based on adventure mode status and world connection.
* Updated ELConfig to trigger visibility refresh on adventure mode setting changes.
* Ensured minimap toggle visibility is updated during ZNet events.