### PR TITLE
Fix multishot extra resource cost

### DIFF
--- a/EpicLoot/src/Magic/MagicItemEffects/MultiShot.cs
+++ b/EpicLoot/src/Magic/MagicItemEffects/MultiShot.cs
@@ -118,7 +118,9 @@ namespace EpicLoot.MagicItemEffects
             weaponDamage.Modify(damage);
             attack.GetWeapon().m_shared.m_damages = weaponDamage;
 
-            ModifyAttackCost(player, costScale, attack.GetAttackStamina(), attack.GetAttackEitr(), attack.GetAttackHealth());
+            // Vanilla spends the base attack cost; multishot only needs to spend the configured extra amount.
+            float extraCostScale = Mathf.Max(0f, costScale - 1f);
+            ModifyAttackCost(player, extraCostScale, attack.GetAttackStamina(), attack.GetAttackEitr(), attack.GetAttackHealth());
 
             attack.m_projectileAccuracy = attack.m_weapon.m_shared.m_attack.m_projectileAccuracy * accuracy;
 


### PR DESCRIPTION
## Summary
- fixes Epic Loot multishot charging the wrong extra resource cost for additional projectiles
- charges only the extra projectile cost instead of charging the full scaled attack cost again
- keeps vanilla responsible for the first shot's normal stamina/eitr/health spend

## Problem
Vanilla already spends the base attack resource cost through the normal attack flow. Epic Loot's multishot code was also charging `cost * CostScale`, which meant the player paid the base cost once through vanilla and then paid a full scaled cost again through multishot.

For eitr weapons such as Elemental Magic projectile weapons, this could make effects like `DoubleMagicShot` overcharge the player relative to the intended extra-shot cost.

## Fix
The multishot extra resource charge now subtracts the vanilla-paid first shot from the configured cost scale before spending resources:

`extraCost = attackCost * (CostScale - 1)`

This makes a `CostScale` of `2` mean two total shots cost two total attacks, not three total attacks.

## Validation
- Confirmed the branch contains one fix commit against upstream `main`
- Confirmed the diff only changes `EpicLoot/src/Magic/MagicItemEffects/MultiShot.cs`
- Built locally with `dotnet build EpicLoot.csproj --no-restore`
