### PR TITLE
Add custom magic effect requirements API

### DIFF
--- a/EpicLoot/API/MagicEffectRequirement.cs
+++ b/EpicLoot/API/MagicEffectRequirement.cs
@@ -1,0 +1,89 @@
+﻿using JetBrains.Annotations;
+using System;
+using System.Collections.Generic;
+
+namespace EpicLoot;
+
+public static partial class API
+{
+    private static readonly Dictionary<string, Func<ItemDrop.ItemData, object, string, bool, bool, bool, bool>> ExternalMagicEffectRequirements = new();
+
+    /// <summary>
+    /// Registers a magic effect requirement predicate for a Requirements.ExternalRequirements value.
+    /// </summary>
+    /// <param name="externalRequirement">The ExternalRequirements value used by magic effect JSON.</param>
+    /// <param name="requirement">
+    /// Predicate arguments are item data, magic item, magic effect type, check loot roll, check augment roll, and check rune roll.
+    /// </param>
+    /// <returns>true if the requirement was registered</returns>
+    [PublicAPI]
+    public static bool RegisterMagicEffectRequirement(string externalRequirement, Func<ItemDrop.ItemData, object, string, bool, bool, bool, bool> requirement)
+    {
+        if (string.IsNullOrWhiteSpace(externalRequirement))
+        {
+            OnError?.Invoke("Failed to register magic effect requirement: external requirement is empty");
+            return false;
+        }
+
+        if (requirement == null)
+        {
+            OnError?.Invoke($"Failed to register magic effect requirement '{externalRequirement}': requirement is null");
+            return false;
+        }
+
+        if (ExternalMagicEffectRequirements.ContainsKey(externalRequirement))
+        {
+            OnError?.Invoke($"Duplicate magic effect requirement: {externalRequirement}");
+            return false;
+        }
+
+        ExternalMagicEffectRequirements[externalRequirement] = requirement;
+        OnReload?.Invoke($"Registered magic effect requirement: {externalRequirement}");
+        return true;
+    }
+
+    internal static bool CheckMagicEffectExternalRequirements(
+        List<string> externalRequirements,
+        ItemDrop.ItemData itemData,
+        MagicItem magicItem,
+        string magicEffectType,
+        bool checklootroll,
+        bool checkaugmentroll,
+        bool checkruneroll)
+    {
+        if (externalRequirements == null || externalRequirements.Count == 0)
+        {
+            return true;
+        }
+
+        foreach (string externalRequirement in externalRequirements)
+        {
+            if (string.IsNullOrWhiteSpace(externalRequirement))
+            {
+                OnError?.Invoke($"Magic effect '{magicEffectType}' has an empty external requirement");
+                return false;
+            }
+
+            if (!ExternalMagicEffectRequirements.TryGetValue(externalRequirement, out Func<ItemDrop.ItemData, object, string, bool, bool, bool, bool> requirement))
+            {
+                OnError?.Invoke($"Magic effect '{magicEffectType}' requires unregistered external requirement '{externalRequirement}'");
+                return false;
+            }
+
+            try
+            {
+                if (!requirement(itemData, magicItem, magicEffectType, checklootroll, checkaugmentroll, checkruneroll))
+                {
+                    return false;
+                }
+            }
+            catch (Exception ex)
+            {
+                OnError?.Invoke($"Magic effect requirement '{externalRequirement}' failed for '{magicEffectType}': {ex.Message}");
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/EpicLoot/info.md
+++ b/EpicLoot/info.md
@@ -34,7 +34,8 @@ Listen to the event `MagicItemEffectDefinitions.OnSetupMagicItemEffectDefinition
     * **ExcludedSkillTypes:** This effect may only be rolled on an item that does not use one of these skill types.
     * **AllowedItemNames:** This effect may only be rolled on an item with one of these names. Use the unlocalized shared name, i.e.: `$item_sword_iron`
     * **ExcludedItemNames:** This effect may only be rolled on an item that does not have one of these names.
-    * **CustomFlags:** A set of any arbitrary strings for future use
+    * **CustomFlags:** A set of arbitrary strings for future use.
+    * **ExternalRequirements:** Requirement keys registered by external plugins through `API.RegisterMagicEffectRequirement`. Every listed key must be registered and must return true for the effect to roll.
   * **Value Per Rarity:** This effect may only be rolled on items of a rarity included in this table. The value is rolled using a linear distribution between Min and Max and divisible by the Increment.
 
 ## DvergerCirclet
@@ -7253,5 +7254,3 @@ A list of every built-in loot table from the mod. The name of the loot table is 
 > | Items (lvl 6) | Weight (Chance) | Magic | Rare | Epic | Legendary |
 > | -- | -- | -- | -- | -- | -- |
 > | Tier6Everything | 1 (100%) | 0 (0%) | 0 (0%) | 65 (65%) | 35 (35%) |
-
-

--- a/EpicLoot/src/Magic/MagicItemEffectDefinition.cs
+++ b/EpicLoot/src/Magic/MagicItemEffectDefinition.cs
@@ -40,6 +40,7 @@ namespace EpicLoot
         public bool? ItemUsesDrawStaminaOnAttack;
 
         public List<string> CustomFlags;
+        public List<string> ExternalRequirements;
 
         public bool AllowByItemType([NotNull] ItemDrop.ItemData itemData)
         {
@@ -285,6 +286,11 @@ namespace EpicLoot
                 {
                     return false;
                 }
+            }
+
+            if (!API.CheckMagicEffectExternalRequirements(ExternalRequirements, itemData, magicItem, magicEffectType, checklootroll, checkaugmentroll, checkruneroll))
+            {
+                return false;
             }
 
             return true;

--- a/EpicLootAPI/EL_API.cs
+++ b/EpicLootAPI/EL_API.cs
@@ -140,6 +140,7 @@ public static class EpicLoot
         public bool? ItemUsesDrawStaminaOnAttack;
 
         public List<string> CustomFlags = new();
+        public List<string> ExternalRequirements = new();
     }
     public enum FxAttachMode
     {
@@ -375,6 +376,7 @@ public static class EpicLoot
     private static readonly Method API_AddAbility = new("EpicLoot.API, EpicLoot", "AddAbility");
     private static readonly Method API_HasLegendaryItem = new("EpicLoot.API, EpicLoot", "HasLegendaryItem");
     private static readonly Method API_HasLegendarySet = new("EpicLoot.API, EpicLoot", "HasLegendarySet");
+    private static readonly Method API_RegisterMagicEffectRequirement = new("EpicLoot.API, EpicLoot", "RegisterMagicEffectRequirement");
 
     public static MagicItemEffectDefinition? GetMagicEffectDefinitionCopy(string effectType)
     {
@@ -404,6 +406,13 @@ public static class EpicLoot
         string data = JsonConvert.SerializeObject(definition);
         object? result = API_AddMagicEffect.Invoke(data);
 
+        return (bool)(result ?? false);
+    }
+
+    [Description("Register a custom requirement for magic effect Requirements.ExternalRequirements")]
+    public static bool RegisterMagicEffectRequirement(string externalRequirement, Func<ItemDrop.ItemData, object, string, bool, bool, bool, bool> requirement)
+    {
+        object? result = API_RegisterMagicEffectRequirement.Invoke(externalRequirement, requirement);
         return (bool)(result ?? false);
     }
 

--- a/EpicLootAPI/EpicLootAPI/README.md
+++ b/EpicLootAPI/EpicLootAPI/README.md
@@ -46,7 +46,13 @@ If you need to update your custom classes, use the API `Update` functions
 ```c#
 public void Awake()
 {
+    EpicLoot.RegisterMagicEffectRequirement(
+        "MyMod.RequiresBow",
+        (itemData, magicItem, effectType, checkLootRoll, checkAugmentRoll, checkRuneRoll) =>
+            itemData.m_shared.m_itemType == ItemDrop.ItemData.ItemType.Bow);
+
     var Definition = new MagicItemEffectDefinition("Blink", "Blink", "Teleport to impact point");
+    Definition.Requirements.ExternalRequirements.Add("MyMod.RequiresBow");
     Definition.Requirements.AllowedSkillTypes.Add(Skills.SkillType.Bows, Skills.SkillType.Spears);
     Definition.Requirements.AllowedRarities.Add(ItemRarity.Epic, ItemRarity.Legendary, ItemRarity.Mythic);
     Definition.SelectionWeight = 1;

--- a/EpicLootAPI/EpicLootAPI/src/API.cs
+++ b/EpicLootAPI/EpicLootAPI/src/API.cs
@@ -1,5 +1,6 @@
 ﻿using JetBrains.Annotations;
 using Newtonsoft.Json;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 
@@ -21,6 +22,10 @@ public static class EpicLoot
     private static readonly Method API_HasLegendarySet = new("HasLegendarySet");
     private static readonly Method API_RegisterAsset = new("RegisterAsset");
     private static readonly Method API_GetMagicItemJson = new("GetMagicItemJson");
+    private static readonly Method API_RegisterMagicEffectRequirement = new(
+        "RegisterMagicEffectRequirement",
+        typeof(string),
+        typeof(Func<ItemDrop.ItemData, object, string, bool, bool, bool, bool>));
 
     [PublicAPI][Description("Send all your custom conversions, effects, item definitions, etc... to Epic Loot")]
     public static void RegisterAll()
@@ -50,6 +55,21 @@ public static class EpicLoot
         object[] result = API_RegisterAsset.Invoke(name, asset);
         bool output = (bool)(result[0] ?? false);
         logger.LogDebug($"Registered asset: {name}, {output}");
+        return output;
+    }
+
+    /// <summary>
+    /// Register a predicate for magic effect Requirements.ExternalRequirements.
+    /// </summary>
+    /// <param name="externalRequirement">The ExternalRequirements value used by magic effect JSON.</param>
+    /// <param name="requirement">Receives item data, magic item object, effect type, loot roll flag, augment roll flag, and rune roll flag.</param>
+    /// <returns>true if Epic Loot registered the requirement</returns>
+    [PublicAPI]
+    public static bool RegisterMagicEffectRequirement(string externalRequirement, Func<ItemDrop.ItemData, object, string, bool, bool, bool, bool> requirement)
+    {
+        object[] result = API_RegisterMagicEffectRequirement.Invoke(externalRequirement, requirement);
+        bool output = (bool)(result[0] ?? false);
+        logger.LogDebug($"Registered magic effect requirement: {externalRequirement}, {output}");
         return output;
     }
     

--- a/EpicLootAPI/EpicLootAPI/src/MagicItemEffect.cs
+++ b/EpicLootAPI/EpicLootAPI/src/MagicItemEffect.cs
@@ -215,6 +215,7 @@ public class MagicItemEffectRequirements
     public bool? ItemUsesDrawStaminaOnAttack;
 
     public List<string> CustomFlags = new();
+    public List<string> ExternalRequirements = new();
 
     public void AddAllowedItemTypes(params ItemDrop.ItemData.ItemType[] types)
     {


### PR DESCRIPTION
## Summary
- add `API.RegisterMagicEffectRequirement` for external magic effect requirement predicates
- add a dedicated `Requirements.ExternalRequirements` list for registered external requirement keys
- keep `Requirements.CustomFlags` as passive arbitrary metadata
- expose the registration helper and `ExternalRequirements` model field through the EpicLootAPI wrapper and docs

## Behavior
Every `ExternalRequirements` entry must be registered by an external plugin and the registered predicate must return true. Missing, empty, or throwing predicates make the effect fail its requirements. Existing `CustomFlags` entries are not evaluated by this API.

## Validation
- `git diff --check`
- PraetorisClient integration build: `dotnet build PraetorisClient.sln` succeeded with 0 warnings and 0 errors
- Live Valnet validation on `valnet-client-01` using a `develop` profile:
  - `DecreaseAdrenalineRequired` registered through the Epic Loot API
  - effect was available on adrenaline item `TrinketBlackDamageHealth`
  - effect was not available on normal item `ArmorAshlandsMediumChest`
- `dotnet build EpicLoot/EpicLoot.sln` could not compile on this Mac because .NET Framework 4.8 reference assemblies are not installed.
- `dotnet build EpicLootAPI/EpicLootAPI.sln` hit the same local .NET Framework 4.8 reference assembly blocker.
